### PR TITLE
Add support for trigger_time

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Configuration parameters are shown below:
 | sequential       | yes       | true if trying to calculate sequential cheapet hours timeframe. False if multiple values are acceptable. |
 | failsafe_starting_hour | no        | If for some reason nord pool prices can't be fetched before first_hour, use failsafe time to turn the sensor on. If failsafe_starting_hour is not given, the failsafe is disabled for the sensor. |
 | inversed         | no        | Want to find expensive hours to avoid? Set to True! default: false |
-
+| trigger_time     | no        | Earliest time to create next cheapest hours. Format: "HH:mm". Useful when waiting for other data to arrive before triggering event creation. Example: 'trigger_time: "19:00"' | 
 ### Example configuration
 The example configuration presents creation of three sensors: one for **nord pool cheapest three hours**, one for **nord pool most expensive prices** and final one for **entso-e cheapest hours**.
 The expensive sensor uses external input_number to get number of hours requested.

--- a/custom_components/aio_energy_management/binary_sensor.py
+++ b/custom_components/aio_energy_management/binary_sensor.py
@@ -23,6 +23,7 @@ from .const import (
     CONF_NUMBER_OF_HOURS,
     CONF_SEQUENTIAL,
     CONF_STARTING_TODAY,
+    CONF_TRIGGER_TIME,
     CONF_UNIQUE_ID,
     COORDINATOR,
     DOMAIN,
@@ -43,6 +44,7 @@ CHEAPEST_HOURS_PLATFORM_SCHEMA = Schema(
         vol.Required(CONF_NUMBER_OF_HOURS): vol.Any(int, cv.entity_id),
         vol.Optional(CONF_FAILSAFE_STARTING_HOUR): int,
         vol.Optional(CONF_INVERSED): bool,
+        vol.Optional(CONF_TRIGGER_TIME): vol.All(vol.Coerce(str)),
     },
     extra=ALLOW_EXTRA,
 )
@@ -86,6 +88,7 @@ def _create_cheapest_hours_entity(
     number_of_hours = discovery_info[CONF_NUMBER_OF_HOURS]
     failsafe_starting_hour = discovery_info.get(CONF_FAILSAFE_STARTING_HOUR)
     inversed = discovery_info.get(CONF_INVERSED) or False
+    trigger_time = discovery_info.get(CONF_TRIGGER_TIME)
 
     return CheapestHoursBinarySensor(
         hass=hass,
@@ -101,4 +104,5 @@ def _create_cheapest_hours_entity(
         sequential=sequential,
         failsafe_starting_hour=failsafe_starting_hour,
         inversed=inversed,
+        trigger_time=trigger_time,
     )

--- a/custom_components/aio_energy_management/const.py
+++ b/custom_components/aio_energy_management/const.py
@@ -13,6 +13,7 @@ CONF_STARTING_TODAY = "starting_today"
 CONF_NUMBER_OF_HOURS = "number_of_hours"
 CONF_FAILSAFE_STARTING_HOUR = "failsafe_starting_hour"
 CONF_INVERSED = "inversed"
+CONF_TRIGGER_TIME = "trigger_time"
 
 # Entities
 CONF_ENTITY_CHEAPEST_HOURS = "cheapest_hours"

--- a/custom_components/aio_energy_management/manifest.json
+++ b/custom_components/aio_energy_management/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "calculated",
   "name": "AIO Energy Management",
   "requirements": [],
-  "version": "0.2.2"
+  "version": "0.2.3"
 }


### PR DESCRIPTION
Trigger time can be used to 'delay' event creation until 3rd data arrives (e.g. before night to read amount of hours required to heat water).