### PR TITLE
Add max price support for non-sequential cheapest hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ Configuration parameters are shown below:
 | sequential       | yes       | true if trying to calculate sequential cheapet hours timeframe. False if multiple values are acceptable. |
 | failsafe_starting_hour | no        | If for some reason nord pool prices can't be fetched before first_hour, use failsafe time to turn the sensor on. If failsafe_starting_hour is not given, the failsafe is disabled for the sensor. |
 | inversed         | no        | Want to find expensive hours to avoid? Set to True! default: false |
-| trigger_time     | no        | Earliest time to create next cheapest hours. Format: "HH:mm". Useful when waiting for other data to arrive before triggering event creation. Example: 'trigger_time: "19:00"' | 
+| trigger_time     | no        | Earliest time to create next cheapest hours. Format: "HH:mm". Useful when waiting for other data to arrive before triggering event creation. Example: 'trigger_time: "19:00"' |
+| max_price        | no        | Only accept prices less than given float value. *Note: given hours might be less than requested if not enough values can be found with given parameters.* Only supported by non-seuqential cheapest_hours |
+
 ### Example configuration
 The example configuration presents creation of three sensors: one for **nord pool cheapest three hours**, one for **nord pool most expensive prices** and final one for **entso-e cheapest hours**.
 The expensive sensor uses external input_number to get number of hours requested.

--- a/custom_components/aio_energy_management/binary_sensor.py
+++ b/custom_components/aio_energy_management/binary_sensor.py
@@ -18,6 +18,7 @@ from .const import (
     CONF_FIRST_HOUR,
     CONF_INVERSED,
     CONF_LAST_HOUR,
+    CONF_MAX_PRICE,
     CONF_NAME,
     CONF_NORDPOOL_ENTITY,
     CONF_NUMBER_OF_HOURS,
@@ -45,6 +46,7 @@ CHEAPEST_HOURS_PLATFORM_SCHEMA = Schema(
         vol.Optional(CONF_FAILSAFE_STARTING_HOUR): int,
         vol.Optional(CONF_INVERSED): bool,
         vol.Optional(CONF_TRIGGER_TIME): vol.All(vol.Coerce(str)),
+        vol.Optional(CONF_MAX_PRICE): float,
     },
     extra=ALLOW_EXTRA,
 )
@@ -89,6 +91,7 @@ def _create_cheapest_hours_entity(
     failsafe_starting_hour = discovery_info.get(CONF_FAILSAFE_STARTING_HOUR)
     inversed = discovery_info.get(CONF_INVERSED) or False
     trigger_time = discovery_info.get(CONF_TRIGGER_TIME)
+    max_price = discovery_info.get(CONF_MAX_PRICE)
 
     return CheapestHoursBinarySensor(
         hass=hass,
@@ -105,4 +108,5 @@ def _create_cheapest_hours_entity(
         failsafe_starting_hour=failsafe_starting_hour,
         inversed=inversed,
         trigger_time=trigger_time,
+        max_price=max_price,
     )

--- a/custom_components/aio_energy_management/cheapest_hours_binary_sensor.py
+++ b/custom_components/aio_energy_management/cheapest_hours_binary_sensor.py
@@ -48,6 +48,7 @@ class CheapestHoursBinarySensor(BinarySensorEntity):
         entsoe_entity=None,
         nordpool_entity=None,
         trigger_time=None,
+        max_price=None,
     ) -> None:
         """Init sensor."""
         self._nordpool_entity = nordpool_entity
@@ -65,15 +66,13 @@ class CheapestHoursBinarySensor(BinarySensorEntity):
         self._number_of_hours = number_of_hours
         self._inversed = inversed
         self._trigger_time = None
+        self._max_price = max_price
 
         if trigger_time is not None:
             self._trigger_time = from_str_to_time(trigger_time)
 
         self.hass = hass
-        # Data
         self._data = self._coordinator.get_data(self._attr_unique_id)
-        if self._data is None:
-            self._data = {}
 
     async def async_update(self) -> None:
         """Update sensor."""
@@ -91,7 +90,7 @@ class CheapestHoursBinarySensor(BinarySensorEntity):
             return False
 
         items = self._data.get("list")
-        if items is None or len(items) == 0:
+        if items is None:
             # No valid data, check failsafe
             _LOGGER.debug("No valid data found. Check failsafe")
             return self._is_failsafe()
@@ -197,6 +196,7 @@ class CheapestHoursBinarySensor(BinarySensorEntity):
                     self._first_hour,
                     self._last_hour,
                     self._inversed,
+                    self._max_price,
                 )
             else:
                 cheapest = calculate_non_sequential_cheapest_hours(
@@ -207,6 +207,7 @@ class CheapestHoursBinarySensor(BinarySensorEntity):
                     self._first_hour,
                     self._last_hour,
                     self._inversed,
+                    self._max_price,
                 )
         except InvalidInput:
             return None
@@ -386,6 +387,7 @@ class CheapestHoursBinarySensor(BinarySensorEntity):
             "is_sequential": self._sequential,
             "failsafe_active": self._is_failsafe(),
             "inversed": self._inversed,
+            "max_price": self._max_price,
         }
 
     def _update_number_of_hours(self) -> None:

--- a/custom_components/aio_energy_management/const.py
+++ b/custom_components/aio_energy_management/const.py
@@ -14,6 +14,7 @@ CONF_NUMBER_OF_HOURS = "number_of_hours"
 CONF_FAILSAFE_STARTING_HOUR = "failsafe_starting_hour"
 CONF_INVERSED = "inversed"
 CONF_TRIGGER_TIME = "trigger_time"
+CONF_MAX_PRICE = "max_price"
 
 # Entities
 CONF_ENTITY_CHEAPEST_HOURS = "cheapest_hours"

--- a/custom_components/aio_energy_management/coordinator.py
+++ b/custom_components/aio_energy_management/coordinator.py
@@ -53,7 +53,10 @@ class EnergyManagementCoordinator:
     def get_data(self, entity_id: str) -> dict | None:
         """Get entity data."""
         _LOGGER.debug("Query data from store for %s", entity_id)
-        return self.data.get(entity_id)
+        data = self.data.get(entity_id)
+        if data is None:
+            data = {}
+        return data
 
     def _convert_datetimes(self, dictionary: dict) -> dict | None:
         for k, v in dictionary.items():

--- a/custom_components/aio_energy_management/math.py
+++ b/custom_components/aio_energy_management/math.py
@@ -21,8 +21,15 @@ def calculate_sequential_cheapest_hours(
     first_hour: int,
     last_hour: int,
     inversed: bool = False,
+    max_price: float | None = None,
 ) -> list:
     """Calculate sequential cheapest hours."""
+    if max_price is not None:  # Max price is not supported on seuqantial calculations
+        _LOGGER.error(
+            "Invalid configuration: max_price not supported by sequential cheapest hours"
+        )
+        raise InvalidInput
+
     if (
         _is_cheapest_hours_input_valid(
             number_of_hours, starting_today, first_hour, last_hour
@@ -78,6 +85,7 @@ def calculate_non_sequential_cheapest_hours(
     first_hour: int,
     last_hour: int,
     inversed: bool = False,
+    max_price: float | None = None,
 ) -> list:
     """Calculate non-sequential cheapest hours."""
     if (
@@ -104,9 +112,11 @@ def calculate_non_sequential_cheapest_hours(
     data.sort(key=lambda x: (x["price"], x["start"]), reverse=inversed)
     data = data[:number_of_hours]
     data.sort(key=lambda x: (x["start"]))
+    if mp := max_price:
+        data = [d for d in data if d["price"] < mp]
 
+    # Combine sequantial slots
     iterate = True
-
     while iterate is True:
         matched = False
         i = 0

--- a/tests/test_cheapest_hours_binary_sensor.py
+++ b/tests/test_cheapest_hours_binary_sensor.py
@@ -11,6 +11,7 @@ from custom_components.aio_energy_management.binary_sensor import (
 from custom_components.aio_energy_management.const import DOMAIN
 from freezegun import freeze_time
 from freezegun.api import FrozenDateTimeFactory
+import numpy as np
 from pytest_homeassistant_custom_component.common import load_fixture
 
 from homeassistant.core import HomeAssistant, State
@@ -505,7 +506,7 @@ async def test_cheapest_hours_entsoe_over_night(
 async def test_trigger_time(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
-    """Test cheapest binary sensors failsafe."""
+    """Test cheapest binary sensors trigger time."""
     coordinator_mock = _setup_coordinator_mock()
     freezer.move_to("2024-07-13 14:25+03:00")
 
@@ -533,3 +534,72 @@ async def test_trigger_time(
     freezer.move_to("2024-07-13 17:00+03:00")
     await sensor.async_update()
     assert sensor.extra_state_attributes.get("list") is not None
+
+
+async def test_max_price(hass: HomeAssistant, freezer: FrozenDateTimeFactory) -> None:
+    """Test cheapest binary sensors max price."""
+    coordinator_mock = _setup_coordinator_mock()
+    freezer.move_to("2024-07-13 14:25+03:00")
+    tzinfo = zoneinfo.ZoneInfo(key="Europe/Helsinki")
+
+    _setup_nordpool_mock(hass, "nordpool_happy_20240713.json")
+
+    # Create sensor to test
+    sensor = CheapestHoursBinarySensor(
+        hass=hass,
+        nordpool_entity="sensor.nordpool",
+        unique_id="my_sensor",
+        name="My Sensor",
+        first_hour=0,
+        last_hour=23,
+        starting_today=False,
+        number_of_hours=3,
+        sequential=False,
+        coordinator=coordinator_mock,
+        max_price=-0.7,
+    )
+
+    await sensor.async_update()
+
+    # Only one hour should be found that is less than -0.7 max price value
+    assert sensor.extra_state_attributes.get("list") is not None
+
+    assert sensor.extra_state_attributes["list"][0]["start"] == datetime(
+        2024, 7, 14, 15, 0, tzinfo=tzinfo
+    )
+    assert sensor.extra_state_attributes["list"][0]["end"] == datetime(
+        2024, 7, 14, 16, 0, tzinfo=tzinfo
+    )
+
+    assert np.size(sensor.extra_state_attributes["list"]) == 1
+
+
+async def test_max_price_no_matches(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
+    """Test cheapest binary sensors max price."""
+    coordinator_mock = _setup_coordinator_mock()
+    freezer.move_to("2024-07-13 14:25+03:00")
+
+    _setup_nordpool_mock(hass, "nordpool_happy_20240713.json")
+
+    # Test zero matches
+    sensor = CheapestHoursBinarySensor(
+        hass=hass,
+        nordpool_entity="sensor.nordpool",
+        unique_id="my_sensor",
+        name="My Sensor",
+        first_hour=0,
+        last_hour=23,
+        starting_today=False,
+        number_of_hours=3,
+        sequential=False,
+        coordinator=coordinator_mock,
+        max_price=-0.8,
+    )
+
+    await sensor.async_update()
+
+    # Only one hour should be found that is less than -0.7 max price value
+    assert sensor.extra_state_attributes.get("list") is not None
+    assert np.size(sensor.extra_state_attributes["list"]) == 0

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -241,3 +241,44 @@ def test_invalid_input(today_valid, tomorrow_valid) -> None:
         calculate_sequential_cheapest_hours(
             today_valid, tomorrow_valid, 2, False, 22, 21
         )
+
+
+@freeze_time("2024-07-22 14:25+03:00")
+def test_non_sequential_cheapest_hours_max_price(today_valid, tomorrow_valid) -> None:
+    """Test non-sequential with max price."""
+    # Start of tomorrow
+    result = calculate_non_sequential_cheapest_hours(
+        today_valid, tomorrow_valid, 10, False, 0, 23, max_price=2.0
+    )
+
+    # Should only find three items in two slots (10, 12, 13)
+    assert np.size(result) == 2
+
+    assert result[0]["start"] == datetime(
+        2024, 7, 23, 10, 0, tzinfo=zoneinfo.ZoneInfo(key="Europe/Helsinki")
+    )
+    assert result[0]["end"] == datetime(
+        2024, 7, 23, 11, 0, tzinfo=zoneinfo.ZoneInfo(key="Europe/Helsinki")
+    )
+
+    assert result[1]["start"] == datetime(
+        2024, 7, 23, 12, 0, tzinfo=zoneinfo.ZoneInfo(key="Europe/Helsinki")
+    )
+    assert result[1]["end"] == datetime(
+        2024, 7, 23, 14, 0, tzinfo=zoneinfo.ZoneInfo(key="Europe/Helsinki")
+    )
+
+    # Test with zero values found as max_price set to very very low
+    result = calculate_non_sequential_cheapest_hours(
+        today_valid, tomorrow_valid, 10, False, 0, 23, max_price=0.1
+    )
+    assert np.size(result) == 0
+
+
+@freeze_time("2024-07-22 14:25+03:00")
+def test_sequential_cheapest_hours_max_price(today_valid, tomorrow_valid) -> None:
+    """Test non-sequential with max price."""
+    with pytest.raises(InvalidInput):  # max price not supported on sequential
+        calculate_sequential_cheapest_hours(
+            today_valid, tomorrow_valid, 10, False, 0, 23, max_price=2.0
+        )


### PR DESCRIPTION
Enhancement: #15

- Max price support only for non-sequential version.
- List might not have requested amount of hours if not enough values are found with given max_price, use with caution