### PR TITLE
Add extra verification for nord pool validity. Fix proposal for #33

### DIFF
--- a/custom_components/aio_energy_management/helpers.py
+++ b/custom_components/aio_energy_management/helpers.py
@@ -59,3 +59,9 @@ def merge_two_dicts(x, y):
     z = x.copy()  # start with keys and values of x
     z.update(y)  # modifies z with keys and values of y
     return z
+
+def get_first(iterable, default=None):
+    if iterable:
+        for item in iterable:
+            return item
+    return default


### PR DESCRIPTION
Ensure date of first data item on Nord Pool when checking for validity. 
Issue might be caused by Nord Pool integration still returning old data after midnight as we rely only on tomorrow_valid.