### PR TITLE
Support for max_price and trigger_hour to get value from another entity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ Configuration parameters are shown below:
 | sequential       | yes       | true if trying to calculate sequential cheapet hours timeframe. False if multiple values are acceptable. |
 | failsafe_starting_hour | no        | If for some reason nord pool prices can't be fetched before first_hour, use failsafe time to turn the sensor on. If failsafe_starting_hour is not given, the failsafe is disabled for the sensor. |
 | inversed         | no        | Want to find expensive hours to avoid? Set to True! default: false |
-| trigger_time     | no        | Earliest time to create next cheapest hours. Format: "HH:mm". Useful when waiting for other data to arrive before triggering event creation. Example: 'trigger_time: "19:00"' |
-| max_price        | no        | Only accept prices less than given float value. *Note: given hours might be less than requested if not enough values can be found with given parameters.* Only supported by non-seuqential cheapest_hours |
+| trigger_time     | no        | Earliest time to create next cheapest hours. Format: "HH:mm". Useful when waiting for other data to arrive before triggering event creation. Example: 'trigger_time: "19:00"' **! Deprecated: use trigger_hour instead !** |
+| max_price        | no        | Only accept prices less than given float value. *Note: given hours might be less than requested if not enough values can be found with given parameters.* Only supported by non-seuqential cheapest_hours. Can contain entity_id of dynamic entity to get value from e.g. input_number |
+| trigger_hour     | no        | Earliest hour to create next cheapest hours.  "HH:mm". Useful when waiting for other data to arrive before triggering event creation. Example: 'trigger_hour: 19'. Can contain entity_id of dynamic entity to get value from e.g. input_number |
 
 ### Example configuration
 The example configuration presents creation of three sensors: one for **nord pool cheapest three hours**, one for **nord pool most expensive prices** and final one for **entso-e cheapest hours**.
@@ -88,7 +89,7 @@ aio_energy_management:
         first_hour: 0
         last_hour: 22
         starting_today: false
-        number_of_hours: input_number.my_input_number
+        number_of_hours: 4
         sequential: false
         failsafe_starting_hour: 1
         inversed: true
@@ -120,6 +121,34 @@ aio_energy_management:
     unique_id: energy_management_calendar
 ```
 
+
+## Full example with Nord Pool cheapest hours, expensive hours and a calendar
+```
+aio_energy_management:
+    cheapest_hours:
+      - nordpool_entity: sensor.nordpool
+        unique_id: my_cheapest_hours
+        name: My Cheapest Hours
+        first_hour: 21
+        last_hour: 12
+        starting_today: true
+        number_of_hours: 3
+        sequential: false
+        failsafe_starting_hour: 1
+      - nordpool_entity: sensor.nordpool
+        unique_id: my_expensive_hours
+        name: Expensive Hours
+        first_hour: 0
+        last_hour: 22
+        starting_today: false
+        number_of_hours: 4
+        sequential: false
+        failsafe_starting_hour: 1
+        inversed: true
+  calendar:
+    name: Energy Management
+    unique_id: energy_management_calendar
+```
 
 ## Support the developer?
 [!["Buy Me A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/tokorhon)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Configuration parameters are shown below:
 | failsafe_starting_hour | no        | If for some reason nord pool prices can't be fetched before first_hour, use failsafe time to turn the sensor on. If failsafe_starting_hour is not given, the failsafe is disabled for the sensor. |
 | inversed         | no        | Want to find expensive hours to avoid? Set to True! default: false |
 | trigger_time     | no        | Earliest time to create next cheapest hours. Format: "HH:mm". Useful when waiting for other data to arrive before triggering event creation. Example: 'trigger_time: "19:00"' **! Deprecated: use trigger_hour instead !** |
-| max_price        | no        | Only accept prices less than given float value. *Note: given hours might be less than requested if not enough values can be found with given parameters.* Only supported by non-seuqential cheapest_hours. Can contain entity_id of dynamic entity to get value from e.g. input_number |
+| price_limit      | no        | Only accept prices less than given float value or more than given float value if inversed is used. *Note: given hours might be less than requested if not enough values can be found with given parameters.* Only supported by non-seuqential cheapest_hours. Can contain entity_id of dynamic entity to get value from e.g. input_number |
 | trigger_hour     | no        | Earliest hour to create next cheapest hours.  "HH:mm". Useful when waiting for other data to arrive before triggering event creation. Example: 'trigger_hour: 19'. Can contain entity_id of dynamic entity to get value from e.g. input_number |
 
 ### Example configuration

--- a/custom_components/aio_energy_management/binary_sensor.py
+++ b/custom_components/aio_energy_management/binary_sensor.py
@@ -24,6 +24,7 @@ from .const import (
     CONF_NUMBER_OF_HOURS,
     CONF_SEQUENTIAL,
     CONF_STARTING_TODAY,
+    CONF_TRIGGER_HOUR,
     CONF_TRIGGER_TIME,
     CONF_UNIQUE_ID,
     COORDINATOR,
@@ -46,7 +47,8 @@ CHEAPEST_HOURS_PLATFORM_SCHEMA = Schema(
         vol.Optional(CONF_FAILSAFE_STARTING_HOUR): int,
         vol.Optional(CONF_INVERSED): bool,
         vol.Optional(CONF_TRIGGER_TIME): vol.All(vol.Coerce(str)),
-        vol.Optional(CONF_MAX_PRICE): float,
+        vol.Optional(CONF_TRIGGER_HOUR): vol.Any(int, cv.entity_id),
+        vol.Optional(CONF_MAX_PRICE): vol.Any(float, cv.entity_id),
     },
     extra=ALLOW_EXTRA,
 )
@@ -92,6 +94,7 @@ def _create_cheapest_hours_entity(
     inversed = discovery_info.get(CONF_INVERSED) or False
     trigger_time = discovery_info.get(CONF_TRIGGER_TIME)
     max_price = discovery_info.get(CONF_MAX_PRICE)
+    trigger_hour = discovery_info.get(CONF_TRIGGER_HOUR)
 
     return CheapestHoursBinarySensor(
         hass=hass,
@@ -108,5 +111,6 @@ def _create_cheapest_hours_entity(
         failsafe_starting_hour=failsafe_starting_hour,
         inversed=inversed,
         trigger_time=trigger_time,
+        trigger_hour=trigger_hour,
         max_price=max_price,
     )

--- a/custom_components/aio_energy_management/binary_sensor.py
+++ b/custom_components/aio_energy_management/binary_sensor.py
@@ -22,6 +22,7 @@ from .const import (
     CONF_NAME,
     CONF_NORDPOOL_ENTITY,
     CONF_NUMBER_OF_HOURS,
+    CONF_PRICE_LIMIT,
     CONF_SEQUENTIAL,
     CONF_STARTING_TODAY,
     CONF_TRIGGER_HOUR,
@@ -49,6 +50,7 @@ CHEAPEST_HOURS_PLATFORM_SCHEMA = Schema(
         vol.Optional(CONF_TRIGGER_TIME): vol.All(vol.Coerce(str)),
         vol.Optional(CONF_TRIGGER_HOUR): vol.Any(int, cv.entity_id),
         vol.Optional(CONF_MAX_PRICE): vol.Any(float, cv.entity_id),
+        vol.Optional(CONF_PRICE_LIMIT): vol.Any(float, cv.entity_id),
     },
     extra=ALLOW_EXTRA,
 )
@@ -93,8 +95,12 @@ def _create_cheapest_hours_entity(
     failsafe_starting_hour = discovery_info.get(CONF_FAILSAFE_STARTING_HOUR)
     inversed = discovery_info.get(CONF_INVERSED) or False
     trigger_time = discovery_info.get(CONF_TRIGGER_TIME)
-    max_price = discovery_info.get(CONF_MAX_PRICE)
+    price_limit = discovery_info.get(
+        CONF_MAX_PRICE
+    )  # DEPRECATED: replaced by price_limit. Keep here for few releases.
     trigger_hour = discovery_info.get(CONF_TRIGGER_HOUR)
+    if pl := discovery_info.get(CONF_PRICE_LIMIT):
+        price_limit = pl
 
     return CheapestHoursBinarySensor(
         hass=hass,
@@ -112,5 +118,5 @@ def _create_cheapest_hours_entity(
         inversed=inversed,
         trigger_time=trigger_time,
         trigger_hour=trigger_hour,
-        max_price=max_price,
+        price_limit=price_limit,
     )

--- a/custom_components/aio_energy_management/cheapest_hours_binary_sensor.py
+++ b/custom_components/aio_energy_management/cheapest_hours_binary_sensor.py
@@ -1,6 +1,5 @@
 """Nord pool cheapet hours binary sensor."""
 
-import contextlib
 from datetime import date, datetime, timedelta
 import logging
 
@@ -52,7 +51,7 @@ class CheapestHoursBinarySensor(BinarySensorEntity):
         nordpool_entity=None,
         trigger_time=None,
         trigger_hour=None,
-        max_price=None,
+        price_limit=None,
     ) -> None:
         """Init sensor."""
         self._nordpool_entity = nordpool_entity
@@ -71,7 +70,7 @@ class CheapestHoursBinarySensor(BinarySensorEntity):
         self._inversed = inversed
         self._trigger_time = None
         self._trigger_hour = trigger_hour
-        self._max_price = max_price
+        self._price_limit = price_limit
 
         if trigger_time is not None:
             self._trigger_time = from_str_to_time(trigger_time)
@@ -203,7 +202,7 @@ class CheapestHoursBinarySensor(BinarySensorEntity):
                     self._first_hour,
                     self._last_hour,
                     self._inversed,
-                    self._max_price,
+                    self._data.get("active_price_limit")
                 )
             else:
                 cheapest = calculate_non_sequential_cheapest_hours(
@@ -214,7 +213,7 @@ class CheapestHoursBinarySensor(BinarySensorEntity):
                     self._first_hour,
                     self._last_hour,
                     self._inversed,
-                    self._max_price,
+                    self._data.get("active_price_limit")
                 )
         except InvalidInput:
             return None
@@ -408,11 +407,10 @@ class CheapestHoursBinarySensor(BinarySensorEntity):
             "is_sequential": self._sequential,
             "failsafe_active": self._is_failsafe(),
             "inversed": self._inversed,
-            "max_price": self._max_price,
         }
 
-        if max_price := self._max_price:
-            attrs["max_price"] = max_price
+        if price_limit := self._price_limit:
+            attrs["price_limit"] = self._price_limit
         if trigger_time := self._trigger_time:
             attrs["trigger_time"] = trigger_time
         if trigger_hour := self._trigger_hour:
@@ -426,8 +424,8 @@ class CheapestHoursBinarySensor(BinarySensorEntity):
         )
         if trigger_hour := self._trigger_hour:
             self._data["active_trigger_hour"] = self._int_from_entity(trigger_hour)
-        if max_price := self._max_price:
-            self._data["active_max_price"] = self._float_from_entity(max_price)
+        if price_limit := self._price_limit:
+            self._data["active_price_limit"] = self._float_from_entity(price_limit)
 
     def _float_from_entity(self, entity_id) -> float | None:
         """Get float value from another entity."""

--- a/custom_components/aio_energy_management/const.py
+++ b/custom_components/aio_energy_management/const.py
@@ -14,6 +14,7 @@ CONF_NUMBER_OF_HOURS = "number_of_hours"
 CONF_FAILSAFE_STARTING_HOUR = "failsafe_starting_hour"
 CONF_INVERSED = "inversed"
 CONF_TRIGGER_TIME = "trigger_time"
+CONF_TRIGGER_HOUR = "trigger_hour"
 CONF_MAX_PRICE = "max_price"
 
 # Entities

--- a/custom_components/aio_energy_management/const.py
+++ b/custom_components/aio_energy_management/const.py
@@ -13,9 +13,10 @@ CONF_STARTING_TODAY = "starting_today"
 CONF_NUMBER_OF_HOURS = "number_of_hours"
 CONF_FAILSAFE_STARTING_HOUR = "failsafe_starting_hour"
 CONF_INVERSED = "inversed"
-CONF_TRIGGER_TIME = "trigger_time"
+CONF_TRIGGER_TIME = "trigger_time"  # DEPRECATED: use trigger_hour instead
 CONF_TRIGGER_HOUR = "trigger_hour"
-CONF_MAX_PRICE = "max_price"
+CONF_MAX_PRICE = "max_price"  # DEPRECATED: use price_limit instead
+CONF_PRICE_LIMIT = "price_limit"
 
 # Entities
 CONF_ENTITY_CHEAPEST_HOURS = "cheapest_hours"

--- a/custom_components/aio_energy_management/helpers.py
+++ b/custom_components/aio_energy_management/helpers.py
@@ -60,7 +60,9 @@ def merge_two_dicts(x, y):
     z.update(y)  # modifies z with keys and values of y
     return z
 
+
 def get_first(iterable, default=None):
+    """Get first item of array."""
     if iterable:
         for item in iterable:
             return item

--- a/custom_components/aio_energy_management/math.py
+++ b/custom_components/aio_energy_management/math.py
@@ -21,12 +21,12 @@ def calculate_sequential_cheapest_hours(
     first_hour: int,
     last_hour: int,
     inversed: bool = False,
-    max_price: float | None = None,
+    price_limit: float | None = None,
 ) -> list:
     """Calculate sequential cheapest hours."""
-    if max_price is not None:  # Max price is not supported on seuqantial calculations
+    if price_limit is not None:  # Max price is not supported on seuqantial calculations
         _LOGGER.error(
-            "Invalid configuration: max_price not supported by sequential cheapest hours"
+            "Invalid configuration: price_limit not supported by sequential cheapest hours"
         )
         raise InvalidInput
 
@@ -85,7 +85,7 @@ def calculate_non_sequential_cheapest_hours(
     first_hour: int,
     last_hour: int,
     inversed: bool = False,
-    max_price: float | None = None,
+    price_limit: float | None = None,
 ) -> list:
     """Calculate non-sequential cheapest hours."""
     if (
@@ -112,8 +112,11 @@ def calculate_non_sequential_cheapest_hours(
     data.sort(key=lambda x: (x["price"], x["start"]), reverse=inversed)
     data = data[:number_of_hours]
     data.sort(key=lambda x: (x["start"]))
-    if mp := max_price:
-        data = [d for d in data if d["price"] < mp]
+    if inversed:
+        if mp := price_limit:
+            data = [d for d in data if d["price"] >= mp]
+    elif mp := price_limit:
+        data = [d for d in data if d["price"] <= mp]
 
     # Combine sequantial slots
     iterate = True

--- a/tests/test_cheapest_hours_binary_sensor.py
+++ b/tests/test_cheapest_hours_binary_sensor.py
@@ -656,7 +656,7 @@ async def test_max_price(hass: HomeAssistant, freezer: FrozenDateTimeFactory) ->
         number_of_hours=3,
         sequential=False,
         coordinator=coordinator_mock,
-        max_price=-0.7,
+        price_limit=-0.7,
     )
 
     await sensor.async_update()
@@ -695,7 +695,7 @@ async def test_max_price_no_matches(
         number_of_hours=3,
         sequential=False,
         coordinator=coordinator_mock,
-        max_price=-0.8,
+        price_limit=-0.8,
     )
 
     await sensor.async_update()
@@ -744,3 +744,4 @@ async def test_failsafe(hass: HomeAssistant, freezer: FrozenDateTimeFactory) -> 
     await sensor.async_update()
     assert sensor.is_on is False
     assert sensor.extra_state_attributes.get("list") == []
+

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -248,7 +248,7 @@ def test_non_sequential_cheapest_hours_max_price(today_valid, tomorrow_valid) ->
     """Test non-sequential with max price."""
     # Start of tomorrow
     result = calculate_non_sequential_cheapest_hours(
-        today_valid, tomorrow_valid, 10, False, 0, 23, max_price=2.0
+        today_valid, tomorrow_valid, 10, False, 0, 23, price_limit=2.0
     )
 
     # Should only find three items in two slots (10, 12, 13)
@@ -270,7 +270,39 @@ def test_non_sequential_cheapest_hours_max_price(today_valid, tomorrow_valid) ->
 
     # Test with zero values found as max_price set to very very low
     result = calculate_non_sequential_cheapest_hours(
-        today_valid, tomorrow_valid, 10, False, 0, 23, max_price=0.1
+        today_valid, tomorrow_valid, 10, False, 0, 23, price_limit=0.1
+    )
+    assert np.size(result) == 0
+
+
+@freeze_time("2024-07-22 14:25+03:00")
+def test_non_sequential_cheapest_hours_min_price(today_valid, tomorrow_valid) -> None:
+    """Test non-sequential with max price."""
+    # Start of tomorrow
+    result = calculate_non_sequential_cheapest_hours(
+        today_valid, tomorrow_valid, 10, False, 0, 23, inversed=True, price_limit=4.75
+    )
+
+    # Should only find two items (11, 14)
+    assert np.size(result) == 2
+
+    assert result[0]["start"] == datetime(
+        2024, 7, 23, 11, 0, tzinfo=zoneinfo.ZoneInfo(key="Europe/Helsinki")
+    )
+    assert result[0]["end"] == datetime(
+        2024, 7, 23, 12, 0, tzinfo=zoneinfo.ZoneInfo(key="Europe/Helsinki")
+    )
+
+    assert result[1]["start"] == datetime(
+        2024, 7, 23, 14, 0, tzinfo=zoneinfo.ZoneInfo(key="Europe/Helsinki")
+    )
+    assert result[1]["end"] == datetime(
+        2024, 7, 23, 15, 0, tzinfo=zoneinfo.ZoneInfo(key="Europe/Helsinki")
+    )
+
+    # Test with zero values found as min_price set to very very low
+    result = calculate_non_sequential_cheapest_hours(
+        today_valid, tomorrow_valid, 10, False, 0, 23, inversed=True, price_limit=28
     )
     assert np.size(result) == 0
 
@@ -280,5 +312,5 @@ def test_sequential_cheapest_hours_max_price(today_valid, tomorrow_valid) -> Non
     """Test non-sequential with max price."""
     with pytest.raises(InvalidInput):  # max price not supported on sequential
         calculate_sequential_cheapest_hours(
-            today_valid, tomorrow_valid, 10, False, 0, 23, max_price=2.0
+            today_valid, tomorrow_valid, 10, False, 0, 23, price_limit=2.0
         )


### PR DESCRIPTION
- Add max_price to support value for another entity
- Add new trigger_hour variable to support int or value from another entity. 
- Add support for price_limit that can be used also on inversed functionality (#34, #35)
- Deprecated trigger_time -> **use trigger_hour instead**
- Deprecated max_price -> **use price_limit instead**
