### PR TITLE
Adds support to hide calendar events for selected cheapest hours entities

### DIFF
--- a/custom_components/aio_energy_management/binary_sensor.py
+++ b/custom_components/aio_energy_management/binary_sensor.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .cheapest_hours_binary_sensor import CheapestHoursBinarySensor
 from .const import (
+    CONF_CALENDAR,
     CONF_ENTITY_CHEAPEST_HOURS,
     CONF_ENTSOE_ENTITY,
     CONF_FAILSAFE_STARTING_HOUR,
@@ -51,6 +52,7 @@ CHEAPEST_HOURS_PLATFORM_SCHEMA = Schema(
         vol.Optional(CONF_TRIGGER_HOUR): vol.Any(int, cv.entity_id),
         vol.Optional(CONF_MAX_PRICE): vol.Any(float, cv.entity_id),
         vol.Optional(CONF_PRICE_LIMIT): vol.Any(float, cv.entity_id),
+        vol.Optional(CONF_CALENDAR): bool,
     },
     extra=ALLOW_EXTRA,
 )
@@ -99,8 +101,13 @@ def _create_cheapest_hours_entity(
         CONF_MAX_PRICE
     )  # DEPRECATED: replaced by price_limit. Keep here for few releases.
     trigger_hour = discovery_info.get(CONF_TRIGGER_HOUR)
+    calendar = discovery_info.get(CONF_CALENDAR)
+    if calendar is None:
+        calendar = True
     if pl := discovery_info.get(CONF_PRICE_LIMIT):
         price_limit = pl
+    print(f"ZZZZ: discovery_info = {discovery_info}")
+    print(f"ZZZZ: calendar = {calendar}")
 
     return CheapestHoursBinarySensor(
         hass=hass,
@@ -119,4 +126,5 @@ def _create_cheapest_hours_entity(
         trigger_time=trigger_time,
         trigger_hour=trigger_hour,
         price_limit=price_limit,
+        calendar=calendar,
     )

--- a/custom_components/aio_energy_management/calendar.py
+++ b/custom_components/aio_energy_management/calendar.py
@@ -106,6 +106,10 @@ class EnergyManagementCalendar(CalendarEntity):
         events: list[CalendarEvent] = []
 
         for k, v in self._coordinator.data.items():
+            # Don't add to calendar if disabled by config
+            if v.get("calendar") is False:
+                continue
+
             if d := v.get("list"):
                 for value in d:
                     start = value.get("start")

--- a/custom_components/aio_energy_management/cheapest_hours_binary_sensor.py
+++ b/custom_components/aio_energy_management/cheapest_hours_binary_sensor.py
@@ -52,6 +52,7 @@ class CheapestHoursBinarySensor(BinarySensorEntity):
         trigger_time=None,
         trigger_hour=None,
         price_limit=None,
+        calendar=True,
     ) -> None:
         """Init sensor."""
         self._nordpool_entity = nordpool_entity
@@ -71,6 +72,7 @@ class CheapestHoursBinarySensor(BinarySensorEntity):
         self._trigger_time = None
         self._trigger_hour = trigger_hour
         self._price_limit = price_limit
+        self._calendar = calendar
 
         if trigger_time is not None:
             self._trigger_time = from_str_to_time(trigger_time)
@@ -237,6 +239,7 @@ class CheapestHoursBinarySensor(BinarySensorEntity):
         await self._coordinator.async_set_data(
             self._attr_unique_id,
             self._attr_name,
+            self._calendar,
             self.__class__.__name__,
             self._data,
         )

--- a/custom_components/aio_energy_management/const.py
+++ b/custom_components/aio_energy_management/const.py
@@ -17,6 +17,7 @@ CONF_TRIGGER_TIME = "trigger_time"  # DEPRECATED: use trigger_hour instead
 CONF_TRIGGER_HOUR = "trigger_hour"
 CONF_MAX_PRICE = "max_price"  # DEPRECATED: use price_limit instead
 CONF_PRICE_LIMIT = "price_limit"
+CONF_CALENDAR = "calendar"
 
 # Entities
 CONF_ENTITY_CHEAPEST_HOURS = "cheapest_hours"

--- a/custom_components/aio_energy_management/coordinator.py
+++ b/custom_components/aio_energy_management/coordinator.py
@@ -49,12 +49,13 @@ class EnergyManagementCoordinator:
             self.data = self.convert_datetimes(stored)
 
     async def async_set_data(
-        self, entity_id: str, name: str, module: str, dict: dict
+        self, entity_id: str, name: str, calendar: bool, module: str, dict: dict
     ) -> None:
         """Set entity data."""
         self.data[entity_id] = dict
         self.data[entity_id]["name"] = name
         self.data[entity_id]["type"] = module
+        self.data[entity_id]["calendar"] = calendar
         await self._async_save_data()
 
     def get_data(self, entity_id: str) -> dict | None:


### PR DESCRIPTION
Adds new parameter for cheapest hours sensor 'calendar' that can be true or false, depending if the entity should be shown on energy management calendar. Defaults to true.