### PR TITLE
Cheapest hours: Add support for additional costs/price modifications

### DIFF
--- a/custom_components/aio_energy_management/binary_sensor.py
+++ b/custom_components/aio_energy_management/binary_sensor.py
@@ -30,6 +30,7 @@ from .const import (
     CONF_NUMBER_OF_HOURS,
     CONF_OFFSET,
     CONF_PRICE_LIMIT,
+    CONF_PRICE_MODIFICATIONS,
     CONF_SEQUENTIAL,
     CONF_START,
     CONF_STARTING_TODAY,
@@ -72,6 +73,7 @@ CHEAPEST_HOURS_PLATFORM_SCHEMA = Schema(
             },
         },
         vol.Optional(CONF_MTU): vol.Any(15, 60),
+        vol.Optional(CONF_PRICE_MODIFICATIONS): cv.template,
     },
     extra=ALLOW_EXTRA,
 )
@@ -130,6 +132,7 @@ def _create_cheapest_hours_entity(
         calendar = True
     if pl := discovery_info.get(CONF_PRICE_LIMIT):
         price_limit = pl
+    price_modifications = discovery_info.get(CONF_PRICE_MODIFICATIONS)
 
     return CheapestHoursBinarySensor(
         hass=hass,
@@ -152,4 +155,5 @@ def _create_cheapest_hours_entity(
         calendar=calendar,
         offset=offset,
         mtu=mtu,
+        price_modifications=price_modifications,
     )

--- a/custom_components/aio_energy_management/const.py
+++ b/custom_components/aio_energy_management/const.py
@@ -26,7 +26,7 @@ CONF_HOURS = "hours"
 CONF_MINUTES = "minutes"
 CONF_TRIGGER = "trigger"
 CONF_MTU = "mtu"
-
+CONF_PRICE_MODIFICATIONS = "price_modifications"
 
 # Entities
 CONF_ENTITY_CHEAPEST_HOURS = "cheapest_hours"


### PR DESCRIPTION
Can be used to add tariffs, taxes or other price conversions e.g. EUR/mWh -> snt/kWh