### PR TITLE
fix: guard _int_from_entity / _float_from_entity against unavailable state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # All in One Energy Management for Home Assistant
 Purpose of this component is to provide easily configurable energy management for Home Assistant automations.
 
-During the first phase it supports only to find Nord Pool / Strømligning cheapest hours (or most expensive) per day and automatic calendar creation.
-Later AIO Energy Management is planned to integrate into solar forecast to get support for solar energy usage.
+* Supports finding Nord Pool / Entso-E / Strømligning cheapest hours (or most expensive) per day and automatic calendar creation.
+* Supports excess solar energy routing to selected device(s)
 
 Read more detailed information at the [creatingsmarthome.com](https://www.creatingsmarthome.com/index.php/tag/aio-energy-management/) blog
 

--- a/custom_components/aio_energy_management/cheapest_hours/binary_sensor.py
+++ b/custom_components/aio_energy_management/cheapest_hours/binary_sensor.py
@@ -4,7 +4,7 @@ from datetime import date, datetime, timedelta
 import logging
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.const import STATE_UNKNOWN
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.template import Template
@@ -921,11 +921,18 @@ class CheapestHoursBinarySensor(BinarySensorEntity):
         if isinstance(entity_id, float):
             return entity_id
 
-        value = self.hass.states.get(entity_id).state
-        if value is not None:
+        state = self.hass.states.get(entity_id)
+        value = state.state if state is not None else None
+        if value in (None, STATE_UNAVAILABLE, STATE_UNKNOWN):
+            _LOGGER.error("Could not get entity state for %s", entity_id)
+            raise InvalidEntityState
+        try:
             return float(value)
-        _LOGGER.error("Could not get entity state for %s", entity_id)
-        raise InvalidEntityState
+        except (TypeError, ValueError) as err:
+            _LOGGER.error(
+                "Entity %s has non-numeric state %r: %s", entity_id, value, err
+            )
+            raise InvalidEntityState from err
 
     def _int_from_entity(self, entity_id) -> int | None:
         """Get int value from another entity."""
@@ -936,11 +943,18 @@ class CheapestHoursBinarySensor(BinarySensorEntity):
         if isinstance(entity_id, float):
             return int(entity_id)
 
-        value = self.hass.states.get(entity_id).state
-        if value is not None:
+        state = self.hass.states.get(entity_id)
+        value = state.state if state is not None else None
+        if value in (None, STATE_UNAVAILABLE, STATE_UNKNOWN):
+            _LOGGER.error("Could not get entity state for %s", entity_id)
+            raise InvalidEntityState
+        try:
             return int(float(value))
-        _LOGGER.error("Could not get entity state for %s", entity_id)
-        raise InvalidEntityState
+        except (TypeError, ValueError) as err:
+            _LOGGER.error(
+                "Entity %s has non-numeric state %r: %s", entity_id, value, err
+            )
+            raise InvalidEntityState from err
 
     def _is_15min_period_in_use(self, data: list) -> bool:
         """Check if data mtu is 15min."""

--- a/tests/test_cheapest_hours_binary_sensor.py
+++ b/tests/test_cheapest_hours_binary_sensor.py
@@ -9,12 +9,15 @@ from custom_components.aio_energy_management.binary_sensor import (
     CheapestHoursBinarySensor,
 )
 from custom_components.aio_energy_management.const import DOMAIN
+from custom_components.aio_energy_management.exceptions import InvalidEntityState
 from freezegun import freeze_time
 from freezegun.api import FrozenDateTimeFactory
 
 import numpy as np
+import pytest
 from pytest_homeassistant_custom_component.common import load_fixture
 
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, State, SupportsResponse
 from homeassistant.helpers.template import Template
 import homeassistant.util.dt as dt_util
@@ -2089,5 +2092,42 @@ async def test_cheapest_hours_stromligning_daytime(
 
     freezer.move_to("2026-04-02 14:30+03:00")
     assert sensor.is_on is True
+
+
+def _make_sensor(hass: HomeAssistant) -> CheapestHoursBinarySensor:
+    return CheapestHoursBinarySensor(
+        hass=hass,
+        nordpool_entity="sensor.nordpool",
+        unique_id="x",
+        name="X",
+        first_hour=0,
+        last_hour=23,
+        starting_today=False,
+        number_of_hours=3,
+        sequential=False,
+        coordinator=_setup_coordinator_mock(),
+    )
+
+
+@pytest.mark.parametrize("bad_state", [STATE_UNAVAILABLE, STATE_UNKNOWN, "n/a"])
+async def test_int_from_entity_handles_non_numeric_state(
+    hass: HomeAssistant, bad_state: str
+) -> None:
+    """Non-numeric helper states must raise InvalidEntityState, not ValueError."""
+    sensor = _make_sensor(hass)
+    hass.states.async_set("input_number.slots", bad_state)
+    with pytest.raises(InvalidEntityState):
+        sensor._int_from_entity("input_number.slots")
+
+
+@pytest.mark.parametrize("bad_state", [STATE_UNAVAILABLE, STATE_UNKNOWN, "n/a"])
+async def test_float_from_entity_handles_non_numeric_state(
+    hass: HomeAssistant, bad_state: str
+) -> None:
+    """Non-numeric helper states must raise InvalidEntityState, not ValueError."""
+    sensor = _make_sensor(hass)
+    hass.states.async_set("input_number.price_limit", bad_state)
+    with pytest.raises(InvalidEntityState):
+        sensor._float_from_entity("input_number.price_limit")
 
 


### PR DESCRIPTION
Fixes #159.

When a referenced helper entity (`number_of_slots`, `trigger_hour`, `price_limit`) is in `unavailable`, `unknown`, or any non-numeric state, `_int_from_entity` raised `ValueError("could not convert string to float: 'unavailable'")`, which propagated past the existing `InvalidEntityState` handler in `async_update` and crashed the entity update.

Now both helpers explicitly reject `STATE_UNAVAILABLE`/`STATE_UNKNOWN`/`None` and wrap the numeric cast so any `ValueError`/`TypeError` is logged and re-raised as `InvalidEntityState`, matching the contract the caller already expects.

Added regression tests covering both helpers across the three bad-state cases; they fail on `main` and pass with this patch. Full test suite: 152 passed.