### PR TITLE
Cheapest hours: gracefully fill single-slot upstream data gaps

### DIFF
--- a/custom_components/aio_energy_management/cheapest_hours/math.py
+++ b/custom_components/aio_energy_management/cheapest_hours/math.py
@@ -291,6 +291,8 @@ def _check_day_light_savings(
             return result
         if len(hours) == 100:
             return _remove_duplicate_starts(hours)
+        if 0 < len(hours) < 96:
+            return _fill_arbitrary_gaps(hours, inversed, expected=96, mtu=mtu)
         return hours
 
     # mtu 60: same two-scenario pattern as mtu=15 for Nord Pool Official data.
@@ -304,7 +306,84 @@ def _check_day_light_savings(
         return result
     if len(hours) == 25:
         return _remove_duplicate_starts(hours)
+    if 0 < len(hours) < 24:
+        return _fill_arbitrary_gaps(hours, inversed, expected=24, mtu=mtu)
     return hours
+
+
+def _fill_arbitrary_gaps(
+    hours: list,
+    inversed: bool,
+    expected: int,
+    mtu: int,
+    max_fill_ratio: float = 0.1,
+) -> list:
+    """Fill non-DST gaps in price data with penalty-value entries.
+
+    Some upstream providers (notably ENTSO-e) occasionally drop a single slot
+    in the middle of the day, so prices_today comes back at 95 (or 23 for
+    hourly) instead of the expected 96 / 24. The DST-specific paths above only
+    fire on exact lengths (92, 100, 23, 25), so a single missing slot falls
+    through and the strict `_is_valid_data_length` check then raises
+    ValueNotFound — the consumer integration silently stops producing
+    cheapest/expensive periods.
+
+    This helper walks consecutive entries, detects any gap whose duration
+    exceeds `mtu` minutes, and inserts synthetic entries with
+    MAX_PRICE_VALUE (or MIN_PRICE_VALUE when `inversed=True`) so the synthetic
+    slot is never picked as cheapest / most-expensive. Any remaining shortfall
+    after gap-filling is padded at the end.
+
+    The fill is bounded by `max_fill_ratio` (default 10 %) of `expected`
+    to avoid papering over fundamentally broken responses; if the shortfall
+    exceeds that cap the input is returned unchanged and the caller's
+    validation will raise as before.
+    """
+    if not hours:
+        return hours
+    if len(hours) >= expected:
+        return hours
+
+    shortfall = expected - len(hours)
+    max_fill = max(1, int(expected * max_fill_ratio))
+    if shortfall > max_fill:
+        _LOGGER.warning(
+            "Refusing to fill %d missing %dmin slot(s); shortfall exceeds max_fill=%d. "
+            "Data provider returned %d items, expected %d.",
+            shortfall, mtu, max_fill, len(hours), expected,
+        )
+        return hours
+
+    value = MIN_PRICE_VALUE if inversed else MAX_PRICE_VALUE
+    step = timedelta(minutes=mtu)
+    result: list = [hours[0]]
+    inserted = 0
+
+    for i in range(1, len(hours)):
+        prev_start = result[-1].start
+        cur_start = hours[i].start
+        gap_minutes = (cur_start - prev_start).total_seconds() / 60.0
+        # Number of synthetic slots that fit strictly between prev and cur.
+        # E.g. prev=00:30, cur=01:00, mtu=15 → gap=30 → 1 synthetic at 00:45.
+        slots_in_gap = max(0, round(gap_minutes / mtu) - 1)
+        for j in range(1, slots_in_gap + 1):
+            result.append(HourPrice(value=value, start=prev_start + step * j))
+            inserted += 1
+        result.append(hours[i])
+
+    # Pad at end if the trailing slot(s) are missing.
+    while len(result) < expected:
+        result.append(HourPrice(value=value, start=result[-1].start + step))
+        inserted += 1
+
+    if inserted:
+        _LOGGER.warning(
+            "Filled %d missing %dmin slot(s) with penalty value to reach expected length %d. "
+            "Likely a transient gap in upstream price data.",
+            inserted, mtu, expected,
+        )
+
+    return result
 
 
 def _is_valid_data_length(hours: list, mtu: int) -> bool:

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -426,3 +426,105 @@ def test_sequential_expensive_hours_price_limit(today_valid, tomorrow_valid) -> 
     )
     assert len(result["list"]) == 1
     assert result["extra"]["mean_price"] is not None
+
+
+def _gen_quarter_hour_prices(day: str, count: int = 96, base: float = 50.0) -> list:
+    """Build a list of `count` 15-min HourPrice entries starting at <day> 00:00."""
+    start = datetime.strptime(f"{day} 00:00", "%Y-%m-%d %H:%M")
+    return [HourPrice(base + i, start + timedelta(minutes=15 * i)) for i in range(count)]
+
+
+@freeze_time("2026-05-28 06:00+03:00")
+def test_sequential_cheapest_hours_fills_single_missing_15min_slot() -> None:
+    """Single missing 15-min slot in `today` is filled and computation succeeds.
+
+    Reproduces the ENTSO-e PT15M scenario where prices_today has 95 items
+    because one quarter-hour slot is absent mid-day. Before the fix this
+    raised ValueNotFound; now the gap is filled with a penalty value and the
+    cheapest-hours selection skips the synthetic slot.
+    """
+    # Make the synthetic slot a clearly *not-cheapest* spot by giving the
+    # neighbourhood a noticeable price; the lowest real prices are placed at
+    # the end of `tomorrow` so the cheapest 4-slot window lands there.
+    today = _gen_quarter_hour_prices("2026-05-28", 96, base=50.0)
+    tomorrow = _gen_quarter_hour_prices("2026-05-29", 96, base=10.0)
+    # Drop the 00:45 slot (index 3) — mimicking the real bselo005 prod data.
+    today_missing = today[:3] + today[4:]
+    assert len(today_missing) == 95
+
+    result = calculate_sequential_cheapest_hours(
+        today_missing,
+        tomorrow,
+        number_of_slots=4,
+        starting_today=False,
+        first_hour=0,
+        last_hour=23,
+        mtu=15,
+    )
+    assert result["list"] != [], "expected cheapest hours to be computed"
+    # The synthetic 00:45 slot has MAX_PRICE_VALUE; the chosen 4-slot window
+    # must not include it (it lives in `today`, not `tomorrow`).
+    first = result["list"][0]
+    assert first["start"].date() == datetime.strptime(
+        "2026-05-29", "%Y-%m-%d"
+    ).date()
+    assert result["extra"]["max_price"] is not None
+    assert result["extra"]["max_price"] < 99999.0  # i.e. didn't pick the penalty
+
+
+@freeze_time("2026-05-28 06:00+03:00")
+def test_sequential_expensive_hours_fills_single_missing_15min_slot() -> None:
+    """Inversed selection also tolerates a single missing 15-min slot.
+
+    The penalty value for inversed mode is MIN_PRICE_VALUE so the synthetic
+    slot can never be picked as the most-expensive window either.
+    """
+    today = _gen_quarter_hour_prices("2026-05-28", 96, base=50.0)
+    tomorrow = _gen_quarter_hour_prices("2026-05-29", 96, base=200.0)
+    today_missing = today[:20] + today[21:]
+    assert len(today_missing) == 95
+
+    result = calculate_sequential_cheapest_hours(
+        today_missing,
+        tomorrow,
+        number_of_slots=4,
+        starting_today=False,
+        first_hour=0,
+        last_hour=23,
+        inversed=True,
+        mtu=15,
+    )
+    assert result["list"] != []
+    # The chosen window must not include any synthetic slot — the penalty is
+    # MIN_PRICE_VALUE in inversed mode, so a window touching it could never
+    # win the "most expensive" comparison.
+    assert result["extra"]["min_price"] is not None
+    assert result["extra"]["min_price"] > -99999.0
+
+
+@freeze_time("2026-05-28 06:00+03:00")
+def test_arbitrary_gap_fill_refuses_large_shortfall() -> None:
+    """Cap kicks in: a deeply incomplete day is NOT silently papered over.
+
+    With 80 items out of 96 (≈ 17 % shortfall, above the 10 % cap) the helper
+    must return the input unchanged so the existing strict-length check still
+    raises ValueNotFound. Otherwise an integration receiving a half-broken
+    day would publish meaningful-looking cheapest/expensive results derived
+    mostly from synthetic penalty values.
+    """
+    from custom_components.aio_energy_management.exceptions import ValueNotFound
+
+    today = _gen_quarter_hour_prices("2026-05-28", 96, base=50.0)
+    tomorrow = _gen_quarter_hour_prices("2026-05-29", 96, base=200.0)
+    today_short = today[:80]  # 80 items, shortfall = 16 > max_fill = 9
+
+    with pytest.raises(ValueNotFound):
+        calculate_sequential_cheapest_hours(
+            today_short,
+            tomorrow,
+            number_of_slots=4,
+            starting_today=False,
+            first_hour=0,
+            last_hour=23,
+            mtu=15,
+        )


### PR DESCRIPTION
ENTSO-e (and likely other providers) occasionally returns prices_today / prices_tomorrow with one or two slots missing — e.g. 95 items for a 15-min day where the slot at 00:45 is absent. The existing DST-specific paths in `_check_day_light_savings` only fire on exact lengths (92, 100 for mtu=15; 23, 25 for mtu=60), so a single missing mid-day slot fell through and `_is_valid_data_length` then raised ValueNotFound — the integration silently stopped producing cheapest/expensive periods.

Add `_fill_arbitrary_gaps` as a fallback for non-DST shortfalls: walk consecutive entries, insert MAX_PRICE_VALUE / MIN_PRICE_VALUE (depending on inversed) into any internal gap longer than `mtu` minutes, then pad the trailing gap if needed. The synthetic slot can never win the cheapest/most-expensive comparison.

Guard with a 10% max_fill_ratio cap so deeply broken responses still fall through to the strict validation — we don't want to silently synthesise meaningful-looking selections from mostly-penalty data.

Tests: cover single-missing-slot for both cheapest and inversed (expensive) selection, plus the cap that refuses to paper over a 17% shortfall.