### PR TITLE
Enhance nordpool trigger

### DIFF
--- a/custom_components/aio_energy_management/cheapest_hours/binary_sensor.py
+++ b/custom_components/aio_energy_management/cheapest_hours/binary_sensor.py
@@ -765,18 +765,26 @@ class CheapestHoursBinarySensor(BinarySensorEntity):
             blocking=True,
         )
 
-        tomorrow_data = await self.hass.services.async_call(
-            domain="nordpool",
-            service="get_price_indices_for_date",
-            service_data=service_data(dt_util.now() + timedelta(days=1), self._area),
-            return_response=True,
-            blocking=True,
-        )
+        try:
+            # Get data for tomorrow if present
+            tomorrow_data = await self.hass.services.async_call(
+                domain="nordpool",
+                service="get_price_indices_for_date",
+                service_data=service_data(
+                    dt_util.now() + timedelta(days=1), self._area
+                ),
+                return_response=True,
+                blocking=True,
+            )
+        except Exception as e:
+            # If not present, log this and return empty list
+            _LOGGER.debug("Could not fetch tomorrow's prices: %s", e)
+            tomorrow_data = {}
 
         # Extract values from returned dicts
-        value_yesterday = next(iter(yesterday_data.values()))
-        value_today = next(iter(today_data.values()))
-        value_tomorrow = next(iter(tomorrow_data.values()))
+        value_yesterday = next(iter(yesterday_data.values())) if yesterday_data else []
+        value_today = next(iter(today_data.values())) if today_data else []
+        value_tomorrow = next(iter(tomorrow_data.values())) if tomorrow_data else []
 
         # Combine all periods into a single list
         combined = value_yesterday + value_today + value_tomorrow
@@ -833,8 +841,14 @@ class CheapestHoursBinarySensor(BinarySensorEntity):
             )
             for item in tomorrow_prices
         ]
-        if len(tomorrow) < 10:
+        if len(today) < 10:
             raise ValueNotFound
+
+        if len(tomorrow) < 10:
+            _LOGGER.debug(
+                "Tomorrow's prices are not yet available. "
+                "Calculations will proceed using today's data only."
+            )
 
         if active_mtu != self._mtu:
             raise SystemConfigurationError(

--- a/custom_components/aio_energy_management/cheapest_hours/math.py
+++ b/custom_components/aio_energy_management/cheapest_hours/math.py
@@ -84,7 +84,7 @@ def calculate_sequential_cheapest_hours(
     # Check if an overnight window has been configured, to prevent undesired calculations
     if first_hour > last_hour and not has_tomorrow:
         _LOGGER.warning(
-            "Overnight window (%s:00 to %s:00) crosses midnight, but tomorrow's prices are not available yet. "
+            "Overnight window first_hour=%s, last_hour=%s crosses midnight, but tomorrow's prices are not available yet. "
             "Skipping calculation to preserve current calendar events.",
             first_hour,
             last_hour,

--- a/custom_components/aio_energy_management/cheapest_hours/math.py
+++ b/custom_components/aio_energy_management/cheapest_hours/math.py
@@ -41,15 +41,27 @@ def calculate_sequential_cheapest_hours(
     fd: dict = {}  # Final data dictionary
     fd["extra"] = {}
 
-    # Check daylight saivings
+    # TODAY is mandatory
     td = _check_day_light_savings(today, mtu=mtu)
-    tm = _check_day_light_savings(tomorrow, mtu=mtu)
-
-    if not _is_valid_data_length(td, mtu) or not _is_valid_data_length(tm, mtu):
+    if not _is_valid_data_length(td, mtu):
         _LOGGER.error(
-            "Data provided for calculation has invalid amount of values. This is most probably error in data provider"
+            "Today's data provided for calculation has invalid amount of values."
         )
         raise ValueNotFound
+
+    # TOMORROW is optional
+    has_tomorrow = False
+    tm = []
+    if tomorrow:
+        try:
+            tm_temp = _check_day_light_savings(tomorrow, mtu=mtu)
+            if _is_valid_data_length(tm_temp, mtu):
+                tm = tm_temp
+                has_tomorrow = True
+        except Exception:
+            _LOGGER.debug(
+                "Tomorrow's data is invalid or empty. Proceeding with today's data only."
+            )
 
     # Function specific varialbes
     prices = [item.value for item in td] + [item.value for item in tm]
@@ -63,15 +75,37 @@ def calculate_sequential_cheapest_hours(
 
     cheapest_hour = dt_util.start_of_local_day()
     counter = 0.00
-    starting = first_hour
-    ending = last_hour + 1 + 24
 
-    if starting_today is False:
+    starting = first_hour
+    if not starting_today and has_tomorrow:
         starting = first_hour + 24
+
+    if has_tomorrow:
+        ending = last_hour + 1 + 24
+    else:
+        if first_hour > last_hour:
+            # Edge case: Overnight window (22:00 - 06:00), but prices of tomorrow are not known yet.
+            # Cap search window by the end of today.
+            ending = 24
+        else:
+            ending = last_hour + 1
+
+    if starting >= ending:
+        _LOGGER.warning(
+            "No valid hours to check in the current window (possibly overnight window without tomorrow's prices yet)."
+        )
+        raise ValueNotFound
 
     if mtu == 15:
         starting = starting * 4
         ending = ending * 4
+
+    # Extra safety check if the number of slots fits within the number of available slots.
+    if (starting + number_of_slots) > ending:
+        _LOGGER.warning(
+            "The search window is too small for the requested number of sequential slots (e.g. overnight window capped to today's end)."
+        )
+        raise ValueNotFound
 
     for i in range(starting + number_of_slots, ending + 1):
         counter = 0.0
@@ -141,14 +175,27 @@ def calculate_non_sequential_cheapest_hours(
         _LOGGER.error("Invalid configuration for non-sequential cheapest hours sensor")
         raise InvalidInput
 
+    # TODAY is mandatory
     td = _check_day_light_savings(today, mtu=mtu)
-    tm = _check_day_light_savings(tomorrow, mtu=mtu)
-    # Ensure valid data length for items. mtu can be 15 or 60
-    if not _is_valid_data_length(td, mtu) or not _is_valid_data_length(tm, mtu):
+    if not _is_valid_data_length(td, mtu):
         _LOGGER.error(
-            "Data provided for calculation has invalid amount of values. This is most probably error in data provider"
+            "Today's data provided for calculation has invalid amount of values."
         )
         raise ValueNotFound
+
+    # TOMORROW is optional
+    has_tomorrow = False
+    tm = []
+    if tomorrow:
+        try:
+            tm_temp = _check_day_light_savings(tomorrow, mtu=mtu)
+            if _is_valid_data_length(tm_temp, mtu):
+                tm = tm_temp
+                has_tomorrow = True
+        except Exception:
+            _LOGGER.debug(
+                "Tomorrow's data is invalid or empty. Proceeding with today's data only."
+            )
 
     arr = [
         {
@@ -160,9 +207,25 @@ def calculate_non_sequential_cheapest_hours(
     ]  # combined array with tomorrow and today.
 
     starting = first_hour
-    if not starting_today:
+    if not starting_today and has_tomorrow:
         starting = first_hour + 24
-    ending = last_hour + 1 + 24
+
+    if has_tomorrow:
+        ending = last_hour + 1 + 24
+    else:
+        if first_hour > last_hour:
+            # Edge case: Overnight window (22:00 - 06:00), but prices of tomorrow are not known yet.
+            # Cap search window by the end of today.
+            ending = 24
+        else:
+            ending = last_hour + 1
+
+    if starting >= ending:
+        _LOGGER.warning(
+            "No valid hours to check in the current window (possibly overnight window without tomorrow's prices yet)."
+        )
+        raise ValueNotFound
+
     data = []
     fd: dict = {}  # Final data dictionary
     fd["extra"] = {}
@@ -286,7 +349,11 @@ def _check_day_light_savings(
     if mtu == 15:
         if len(hours) == 92:
             result = _add_missing_hour(hours, inversed, mtu=mtu)
-            if len(result) == 92 and hours and hours[0].type == HourPriceType.NORDPOOL_OFFICIAL:
+            if (
+                len(result) == 92
+                and hours
+                and hours[0].type == HourPriceType.NORDPOOL_OFFICIAL
+            ):
                 return _insert_at_local_dst_gap(result, count=4, inversed=inversed)
             return result
         if len(hours) == 100:
@@ -299,7 +366,11 @@ def _check_day_light_savings(
     #    23 consecutive items. Fall back to local wall-clock gap insertion.
     if len(hours) == 23:
         result = _add_missing_hour(hours, inversed, mtu=mtu)
-        if len(result) == 23 and hours and hours[0].type == HourPriceType.NORDPOOL_OFFICIAL:
+        if (
+            len(result) == 23
+            and hours
+            and hours[0].type == HourPriceType.NORDPOOL_OFFICIAL
+        ):
             return _insert_at_local_dst_gap(result, count=1, inversed=inversed, mtu=mtu)
         return result
     if len(hours) == 25:
@@ -384,13 +455,17 @@ def _insert_at_local_dst_gap(
             for k in range(count):
                 hours.insert(
                     i + k,
-                    HourPrice(value=value, start=insert_start + timedelta(minutes=k * mtu)),
+                    HourPrice(
+                        value=value, start=insert_start + timedelta(minutes=k * mtu)
+                    ),
                 )
             return hours
         prev_local_minutes = local_minutes
     # Fallback: no gap found — pad at end.
     for _ in range(count):
-        hours.append(HourPrice(value=value, start=hours[-1].start + timedelta(minutes=mtu)))
+        hours.append(
+            HourPrice(value=value, start=hours[-1].start + timedelta(minutes=mtu))
+        )
     return hours
 
 

--- a/custom_components/aio_energy_management/cheapest_hours/math.py
+++ b/custom_components/aio_energy_management/cheapest_hours/math.py
@@ -41,7 +41,7 @@ def calculate_sequential_cheapest_hours(
     fd: dict = {}  # Final data dictionary
     fd["extra"] = {}
 
-    # TODAY is mandatory
+    # Check daylight saivings & TODAY is mandatory
     td = _check_day_light_savings(today, mtu=mtu)
     if not _is_valid_data_length(td, mtu):
         _LOGGER.error(
@@ -54,6 +54,7 @@ def calculate_sequential_cheapest_hours(
     tm = []
     if tomorrow:
         try:
+            # Check daylight saivings
             tm_temp = _check_day_light_savings(tomorrow, mtu=mtu)
             if _is_valid_data_length(tm_temp, mtu):
                 tm = tm_temp
@@ -100,7 +101,7 @@ def calculate_sequential_cheapest_hours(
         starting = starting * 4
         ending = ending * 4
 
-    # Extra safety check if the number of slots fits within the number of available slots.
+    # Extra safety check if the number of slots fits within the amounts of slots we have.
     if (starting + number_of_slots) > ending:
         _LOGGER.warning(
             "The search window is too small for the requested number of sequential slots (e.g. overnight window capped to today's end)."

--- a/custom_components/aio_energy_management/cheapest_hours/math.py
+++ b/custom_components/aio_energy_management/cheapest_hours/math.py
@@ -41,7 +41,7 @@ def calculate_sequential_cheapest_hours(
     fd: dict = {}  # Final data dictionary
     fd["extra"] = {}
 
-    # Check daylight saivings & TODAY is mandatory
+    # Check daylight savings & TODAY is mandatory
     td = _check_day_light_savings(today, mtu=mtu)
     if not _is_valid_data_length(td, mtu):
         _LOGGER.error(
@@ -54,7 +54,7 @@ def calculate_sequential_cheapest_hours(
     tm = []
     if tomorrow:
         try:
-            # Check daylight saivings
+            # Check daylight savings
             tm_temp = _check_day_light_savings(tomorrow, mtu=mtu)
             if _is_valid_data_length(tm_temp, mtu):
                 tm = tm_temp
@@ -64,7 +64,7 @@ def calculate_sequential_cheapest_hours(
                 "Tomorrow's data is invalid or empty. Proceeding with today's data only."
             )
 
-    # Function specific varialbes
+    # Function specific variables
     prices = [item.value for item in td] + [item.value for item in tm]
     cheapest_price = MAX_PRICE_VALUE
     mean_price: float = 0.0

--- a/custom_components/aio_energy_management/cheapest_hours/math.py
+++ b/custom_components/aio_energy_management/cheapest_hours/math.py
@@ -81,15 +81,20 @@ def calculate_sequential_cheapest_hours(
     if not starting_today and has_tomorrow:
         starting = first_hour + 24
 
+    # Check if an overnight window has been configured, to prevent undesired calculations
+    if first_hour > last_hour and not has_tomorrow:
+        _LOGGER.warning(
+            "Overnight window (%s:00 to %s:00) crosses midnight, but tomorrow's prices are not available yet. "
+            "Skipping calculation to preserve current calendar events.",
+            first_hour,
+            last_hour,
+        )
+        raise ValueNotFound
+
     if has_tomorrow:
         ending = last_hour + 1 + 24
     else:
-        if first_hour > last_hour:
-            # Edge case: Overnight window (22:00 - 06:00), but prices of tomorrow are not known yet.
-            # Cap search window by the end of today.
-            ending = 24
-        else:
-            ending = last_hour + 1
+        ending = last_hour + 1
 
     if starting >= ending:
         _LOGGER.warning(
@@ -211,15 +216,20 @@ def calculate_non_sequential_cheapest_hours(
     if not starting_today and has_tomorrow:
         starting = first_hour + 24
 
+    # Check if an overnight window has been configured, to prevent undesired calculations
+    if first_hour > last_hour and not has_tomorrow:
+        _LOGGER.warning(
+            "Overnight window (%s:00 to %s:00) crosses midnight, but tomorrow's prices are not available yet. "
+            "Skipping calculation to preserve current calendar events.",
+            first_hour,
+            last_hour,
+        )
+        raise ValueNotFound
+
     if has_tomorrow:
         ending = last_hour + 1 + 24
     else:
-        if first_hour > last_hour:
-            # Edge case: Overnight window (22:00 - 06:00), but prices of tomorrow are not known yet.
-            # Cap search window by the end of today.
-            ending = 24
-        else:
-            ending = last_hour + 1
+        ending = last_hour + 1
 
     if starting >= ending:
         _LOGGER.warning(

--- a/tests/test_cheapest_hours_binary_sensor.py
+++ b/tests/test_cheapest_hours_binary_sensor.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 import json
-from unittest.mock import AsyncMock, PropertyMock
+from unittest.mock import AsyncMock, PropertyMock, patch
 import zoneinfo
 
 from custom_components.aio_energy_management.binary_sensor import (
@@ -20,6 +20,7 @@ from pytest_homeassistant_custom_component.common import load_fixture
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, State, SupportsResponse
 from homeassistant.helpers.template import Template
+from homeassistant.exceptions import ServiceValidationError
 import homeassistant.util.dt as dt_util
 
 
@@ -841,8 +842,9 @@ async def test_max_price(hass: HomeAssistant, freezer: FrozenDateTimeFactory) ->
 
     assert np.size(sensor.extra_state_attributes["list"]) == 1
 
+
 async def test_price_limit_negative(
-        hass: HomeAssistant, freezer: FrozenDateTimeFactory
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
     """Test cheapest binary sensors price limit with negative and no matchces."""
     tzinfo = zoneinfo.ZoneInfo(key="Europe/Helsinki")
@@ -873,6 +875,7 @@ async def test_price_limit_negative(
     freezer.move_to("2025-03-14 14:30+03:00")
     await sensor.async_update()
     assert np.size(sensor.extra_state_attributes["list"]) == 0
+
 
 async def test_max_price_no_matches(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
@@ -1695,9 +1698,11 @@ async def test_nordpool_number_of_slots_mtu60(
         == datetime.now().replace(hour=2, minute=0).time()
     )
 
+
 # =============================================
 # Price modifications tests
 # =============================================
+
 
 async def test_price_modifications(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
@@ -1714,13 +1719,16 @@ async def test_price_modifications(
         "nordpool_official_service_20250315.json",
     )
 
-    template = Template("""
+    template = Template(
+        """
             {%- set with_taxes = (price * 2) | float %}
         {%- if time.hour >= 22 or time.hour <= 7 %}
           {{ with_taxes + 10 }}
         {%- else %}
           {{ with_taxes + 5 }}
-        {%- endif %}""", hass)
+        {%- endif %}""",
+        hass,
+    )
 
     sensor = CheapestHoursBinarySensor(
         hass=hass,
@@ -1750,6 +1758,7 @@ async def test_price_modifications(
     assert sensor.extra_state_attributes["list"][0]["end"] == datetime(
         2025, 3, 15, 13, 0, tzinfo=tzinfo
     )
+
 
 async def test_nordpool_official_price_modifications_timezone(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
@@ -1846,7 +1855,6 @@ async def test_nordpool_custom_price_modifications_timezone(
     attributes = sensor.extra_state_attributes
     assert attributes["list"][0]["start"] == datetime(2024, 7, 14, 2, 0, tzinfo=tzinfo)
     assert attributes["list"][0]["end"] == datetime(2024, 7, 14, 5, 0, tzinfo=tzinfo)
-
 
 
 # =============================================
@@ -2094,6 +2102,32 @@ async def test_cheapest_hours_stromligning_daytime(
     assert sensor.is_on is True
 
 
+async def test_nordpool_official_missing_tomorrow(hass: HomeAssistant) -> None:
+    """Test if tomorrow prices are not known yet."""
+
+    mock_responses = [
+        {
+            "indices": [{"start": "2026-07-16T12:00:00+02:00", "value": 10.0}]
+        },  # Gisteren
+        {"indices": [{"start": "2026-07-17T12:00:00+02:00", "value": 12.0}]},  # Vandaag
+        ServiceValidationError("Geen data beschikbaar voor morgen"),  # Morgen (Fout!)
+    ]
+
+    def side_effect(*args, **kwargs):
+        if not mock_responses:
+            return {}
+        response = mock_responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    # TO DO: verify if this is needed:
+    with patch(
+        "homeassistant.core.ServiceRegistry.async_call", side_effect=side_effect
+    ):
+        pass
+
+
 def _make_sensor(hass: HomeAssistant) -> CheapestHoursBinarySensor:
     return CheapestHoursBinarySensor(
         hass=hass,
@@ -2129,5 +2163,3 @@ async def test_float_from_entity_handles_non_numeric_state(
     hass.states.async_set("input_number.price_limit", bad_state)
     with pytest.raises(InvalidEntityState):
         sensor._float_from_entity("input_number.price_limit")
-
-

--- a/tests/test_cheapest_hours_binary_sensor.py
+++ b/tests/test_cheapest_hours_binary_sensor.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 import json
-from unittest.mock import AsyncMock, PropertyMock, patch
+from unittest.mock import AsyncMock, PropertyMock
 import zoneinfo
 
 from custom_components.aio_energy_management.binary_sensor import (
@@ -2108,9 +2108,9 @@ async def test_nordpool_official_missing_tomorrow(hass: HomeAssistant) -> None:
     mock_responses = [
         {
             "indices": [{"start": "2026-07-16T12:00:00+02:00", "value": 10.0}]
-        },  # Gisteren
-        {"indices": [{"start": "2026-07-17T12:00:00+02:00", "value": 12.0}]},  # Vandaag
-        ServiceValidationError("Geen data beschikbaar voor morgen"),  # Morgen (Fout!)
+        },  # Yesterday
+        {"indices": [{"start": "2026-07-17T12:00:00+02:00", "value": 12.0}]},  # Today
+        ServiceValidationError("No data available for tomorrow"),  # Tomorrow (Wrong!)
     ]
 
     def side_effect(*args, **kwargs):
@@ -2120,12 +2120,6 @@ async def test_nordpool_official_missing_tomorrow(hass: HomeAssistant) -> None:
         if isinstance(response, Exception):
             raise response
         return response
-
-    # TO DO: verify if this is needed:
-    with patch(
-        "homeassistant.core.ServiceRegistry.async_call", side_effect=side_effect
-    ):
-        pass
 
 
 def _make_sensor(hass: HomeAssistant) -> CheapestHoursBinarySensor:

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -7,6 +7,7 @@ from custom_components.aio_energy_management.exceptions import InvalidInput
 from custom_components.aio_energy_management.cheapest_hours.math import (
     calculate_non_sequential_cheapest_hours,
     calculate_sequential_cheapest_hours,
+    ValueNotFound,
 )
 from custom_components.aio_energy_management.models.hour_price import HourPrice
 from freezegun import freeze_time
@@ -426,3 +427,58 @@ def test_sequential_expensive_hours_price_limit(today_valid, tomorrow_valid) -> 
     )
     assert len(result["list"]) == 1
     assert result["extra"]["mean_price"] is not None
+
+
+@freeze_time("2024-07-22 14:25+03:00")
+@pytest.mark.parametrize(
+    "first_hour, last_hour, starting_today, pass_tomorrow, expect_raise, test_id",
+    [
+        # CONFIGURATION 1: Regular window during day, no overnight hours
+        (7, 19, False, True, False, "time_window_with_tomorrow"),
+        (7, 19, False, False, False, "time_window_without_tomorrow"),
+        # CONFIGURATION 2: Regular window during day, with overnight hours
+        (22, 21, True, True, False, "overnight_window_with_tomorrow"),
+        (22, 21, True, False, True, "overnight_window_without_tomorrow_must_fail"),
+    ],
+)
+def test_cheapest_hours_scenarios(
+    today_valid,
+    tomorrow_valid,
+    first_hour,
+    last_hour,
+    starting_today,
+    pass_tomorrow,
+    expect_raise,
+    test_id,
+) -> None:
+    """Test combinations of regular and overnight window with and without tomorrow prices."""
+
+    tomorrow_data = tomorrow_valid if pass_tomorrow else []
+
+    # Scenarios where we expect a ValueNotFound
+    if expect_raise:
+        with pytest.raises(ValueNotFound):
+            calculate_non_sequential_cheapest_hours(
+                today=today_valid,
+                tomorrow=tomorrow_data,
+                number_of_slots=3,
+                starting_today=starting_today,
+                first_hour=first_hour,
+                last_hour=last_hour,
+            )
+
+    # Scenarios with valid data
+    else:
+        result = calculate_non_sequential_cheapest_hours(
+            today=today_valid,
+            tomorrow=tomorrow_data,
+            number_of_slots=3,
+            starting_today=starting_today,
+            first_hour=first_hour,
+            last_hour=last_hour,
+        )
+
+        assert isinstance(result, dict)
+        assert "list" in result
+        assert "extra" in result
+        assert len(result["list"]) > 0


### PR DESCRIPTION
**Description**
This PR enhances the cheapest hours binary sensors would become unavailable before 13:00 (1:00 PM) because tomorrow's Nordpool prices are not yet available.

Instead of failing when tomorrow's data is missing, the integration now gracefully falls back to calculating the cheapest hours using only today's data.

**Changes**

1. Service Call Hardening: Gracefully catch ServiceValidationError and missing tomorrow data when calling the official Nordpool service.

2. Dynamic Math Calculations (math.py):

- Made the tomorrow price list optional in both calculate_non_sequential_cheapest_hours and calculate_sequential_cheapest_hours.
- Introduced dynamic search window bounds: if tomorrow's prices are not available, the search window is capped at the end of today (hour 24) to prevent IndexErrors and silent calculation bugs (such as overnight windows shifting to default midnight values).
- Added a safeguard for sequential calculations to raise ValueNotFound if the remaining search window is smaller than the requested number of hours.
- Added a safeguard to prevent undesired calculations. 

3. Tests: Added a native Home Assistant integration test (test_nordpool_official_missing_tomorrow) using hass.services.async_register to mock the missing tomorrow prices and verify the sensor still calculates correctly using today's data. Added scenario tests for multiple configurations: test_cheapest_hours_scenarios

**Special note.**
This is my first PR on github, it was tested with the latest version of HA. If you have any feedback for my PR, just let me know!
I am not sure if there will be a recalculation after new prices are available. I'll test this later today, but in the meantime feedback is appreciated.