### PR TITLE
Add number_of_blocks option for non-sequential calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ Configuration parameters are shown below:
 | last_hour        | yes       | Last hour used by cheapest hours calculation |
 | starting_today   | no       | First_hour should be already on the same day. False if next day calculations only (**depreceted** determined automatically since 0.9.0) |
 | sequential       | yes       | True if trying to calculate sequential cheapest hours timeframe. False if multiple values are acceptable. |
-| min_seq_slots    | no        | Minimum number of continuous slots for non-sequential calculations. Ensures that selected hours are grouped in blocks of at least this size (e.g., minimum 2 hours per run). Defaults to 1. |
+| min_seq_slots    | no        | Minimum number of continuous slots for non-sequential calculations. Ensures that selected hours are grouped in blocks of at least this size (e.g., minimum 2 slots per run). Defaults to 1. Will be ignored when `number_of_blocks` is being used. |
+| number_of_blocks    | no        | Allows the creation of multiple blocks for non-sequential calculations. Divides the total number of slots into a specified number of separate continuous blocks. |
 | failsafe_starting_hour | no        | If for some reason Nord Pool prices can't be fetched before first_hour, use failsafe time to turn the sensor on. If failsafe_starting_hour is not given, the failsafe is disabled for the sensor. |
 | inversed         | no        | Want to find expensive hours to avoid? Set to True! default: false |
 | trigger_time     | no        | Earliest time to create next cheapest hours. Format: "HH:mm". Useful when waiting for other data to arrive before triggering event creation. Example: 'trigger_time: "19:00"' **! Deprecated: use trigger_hour instead !** |

--- a/custom_components/aio_energy_management/binary_sensor.py
+++ b/custom_components/aio_energy_management/binary_sensor.py
@@ -39,6 +39,7 @@ from .const import (
     CONF_NUMBER_OF_SLOTS,
     CONF_NUMBER_OF_SLOTS_ENTITY,
     CONF_MIN_SEQ_SLOTS,
+    CONF_NUMBER_OF_BLOCKS,
     CONF_OFFSET,
     CONF_PRICE_LIMIT,
     CONF_PRICE_LIMIT_ENTITY,
@@ -77,6 +78,7 @@ CHEAPEST_HOURS_PLATFORM_SCHEMA = Schema(
         vol.Optional(CONF_NUMBER_OF_HOURS): vol.Any(int, cv.entity_id),
         vol.Optional(CONF_NUMBER_OF_SLOTS): vol.Any(int, cv.entity_id),
         vol.Optional(CONF_MIN_SEQ_SLOTS): vol.Any(int, cv.entity_id),
+        vol.Optional(CONF_NUMBER_OF_BLOCKS): vol.Any(int, cv.entity_id),
         vol.Optional(CONF_FAILSAFE_STARTING_HOUR): int,
         vol.Optional(CONF_INVERSED): bool,
         vol.Optional(CONF_TRIGGER_TIME): vol.All(vol.Coerce(str)),
@@ -194,15 +196,16 @@ def _create_cheapest_hours_entity(
         CONF_NUMBER_OF_SLOTS_ENTITY
     ) or discovery_info.get(CONF_NUMBER_OF_SLOTS)
     min_seq_slots = discovery_info.get(CONF_MIN_SEQ_SLOTS)
+    number_of_blocks = discovery_info.get(CONF_NUMBER_OF_BLOCKS)
     failsafe_starting_hour = discovery_info.get(CONF_FAILSAFE_STARTING_HOUR)
     inversed = discovery_info.get(CONF_INVERSED) or False
     trigger_time = discovery_info.get(CONF_TRIGGER_TIME)
     price_limit = discovery_info.get(
         CONF_MAX_PRICE
     )  # DEPRECATED: replaced by price_limit. Keep here for few releases.
-    trigger_hour = discovery_info.get(
-        CONF_TRIGGER_HOUR_ENTITY
-    ) or discovery_info.get(CONF_TRIGGER_HOUR)
+    trigger_hour = discovery_info.get(CONF_TRIGGER_HOUR_ENTITY) or discovery_info.get(
+        CONF_TRIGGER_HOUR
+    )
     add_flexible = discovery_info.get(CONF_ADD_FLEXIBLE)
     calendar = discovery_info.get(CONF_CALENDAR)
     retention_days = discovery_info.get(CONF_RETENTION_DAYS) or 1
@@ -212,7 +215,9 @@ def _create_cheapest_hours_entity(
     price_modifications = None
     if calendar is None:
         calendar = True
-    if pl := discovery_info.get(CONF_PRICE_LIMIT_ENTITY) or discovery_info.get(CONF_PRICE_LIMIT):
+    if pl := discovery_info.get(CONF_PRICE_LIMIT_ENTITY) or discovery_info.get(
+        CONF_PRICE_LIMIT
+    ):
         price_limit = pl
     if pm := discovery_info.get(CONF_PRICE_MODIFICATIONS):
         price_modifications = cv.template(pm)
@@ -232,6 +237,7 @@ def _create_cheapest_hours_entity(
         number_of_hours=number_of_hours,
         number_of_slots=number_of_slots,
         min_seq_slots=min_seq_slots,
+        number_of_blocks=number_of_blocks,
         coordinator=hass.data[DOMAIN][COORDINATOR],
         sequential=sequential,
         failsafe_starting_hour=failsafe_starting_hour,

--- a/custom_components/aio_energy_management/cheapest_hours/binary_sensor.py
+++ b/custom_components/aio_energy_management/cheapest_hours/binary_sensor.py
@@ -59,6 +59,7 @@ class CheapestHoursBinarySensor(BinarySensorEntity):
         number_of_hours=None,
         number_of_slots=None,
         min_seq_slots=None,
+        number_of_blocks=None,
         failsafe_starting_hour=None,
         inversed=False,
         entsoe_entity=None,
@@ -106,6 +107,7 @@ class CheapestHoursBinarySensor(BinarySensorEntity):
         self._number_of_hours = number_of_hours
         self._number_of_slots = number_of_slots
         self._min_seq_slots = min_seq_slots
+        self._number_of_blocks = number_of_blocks
         self._inversed = inversed
         self._trigger_time = None
         self._trigger_hour = trigger_hour
@@ -376,8 +378,9 @@ class CheapestHoursBinarySensor(BinarySensorEntity):
                     self._data.get(
                         "active_min_seq_slots", 1
                     ),  # make sure it defaults to 1
+                    self._data.get("active_number_of_blocks"),
                 )
-        except (InvalidInput, ValueNotFound):
+        except InvalidInput, ValueNotFound:
             # math.py already logged the reason (e.g. invalid input, or an
             # overnight window without tomorrow's prices yet). These signal that
             # no calculation should happen right now, so skip this update and
@@ -982,6 +985,8 @@ class CheapestHoursBinarySensor(BinarySensorEntity):
                 attrs["flexible_price_limit"] = flexible_price_limit
         if min_seq_slots := self._min_seq_slots:
             attrs["min_seq_slots"] = min_seq_slots
+        if number_of_blocks := self._number_of_blocks:
+            attrs["number_of_blocks"] = number_of_blocks
 
         return attrs
 
@@ -1016,6 +1021,11 @@ class CheapestHoursBinarySensor(BinarySensorEntity):
             )
         if min_seq_slots := self._min_seq_slots:
             self._data["active_min_seq_slots"] = self._int_from_entity(min_seq_slots)
+
+        if number_of_blocks := self._number_of_blocks:
+            self._data["active_number_of_blocks"] = self._int_from_entity(
+                number_of_blocks
+            )
 
     def _float_from_entity(self, entity_id) -> float | None:
         """Get float value from another entity."""

--- a/custom_components/aio_energy_management/cheapest_hours/config_flow.py
+++ b/custom_components/aio_energy_management/cheapest_hours/config_flow.py
@@ -37,6 +37,7 @@ from ..const import (
     CONF_NUMBER_OF_SLOTS,
     CONF_NUMBER_OF_SLOTS_ENTITY,
     CONF_MIN_SEQ_SLOTS,
+    CONF_NUMBER_OF_BLOCKS,
     CONF_OFFSET,
     CONF_PRICE_LIMIT,
     CONF_PRICE_LIMIT_ENTITY,
@@ -392,6 +393,17 @@ def _get_cheapest_hours_advanced_schema(
                 CONF_MIN_SEQ_SLOTS,
                 description={
                     "suggested_value": user_input.get(CONF_MIN_SEQ_SLOTS)
+                    if user_input
+                    else None
+                },
+            )
+        ] = int
+
+        schema_dict[
+            vol.Optional(
+                CONF_NUMBER_OF_BLOCKS,
+                description={
+                    "suggested_value": user_input.get(CONF_NUMBER_OF_BLOCKS)
                     if user_input
                     else None
                 },
@@ -896,6 +908,10 @@ def _validate_advanced_integer_fields(user_input: dict[str, Any]) -> dict[str, s
     if min_seq_slots is not None and min_seq_slots < 1:
         errors[CONF_MIN_SEQ_SLOTS] = "min_seq_slots_out_of_range"
 
+    number_of_blocks = user_input.get(CONF_NUMBER_OF_BLOCKS)
+    if number_of_blocks is not None and number_of_blocks < 1:
+        errors[CONF_NUMBER_OF_BLOCKS] = "number_of_blocks_out_of_range"
+
     return errors
 
 
@@ -1082,6 +1098,9 @@ class CheapestHoursConfigFlowMixin:
                 self._config_data.pop(CONF_ADD_FLEXIBLE, None)
                 user_input.pop(CONF_MIN_SEQ_SLOTS, None)
                 self._config_data.pop(CONF_MIN_SEQ_SLOTS, None)
+                user_input.pop(CONF_NUMBER_OF_BLOCKS, None)
+                self._config_data.pop(CONF_NUMBER_OF_BLOCKS, None)
+
             else:
                 flexible_errors = _validate_and_build_add_flexible(
                     user_input,

--- a/custom_components/aio_energy_management/cheapest_hours/math.py
+++ b/custom_components/aio_energy_management/cheapest_hours/math.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import logging
 
 import numpy as np
+import math
 
 import homeassistant.util.dt as dt_util
 
@@ -173,6 +174,7 @@ def calculate_non_sequential_cheapest_hours(
     max_number_of_slots: int | None = None,
     flexible_price_limit: float | None = None,
     min_seq_slots: int = 1,  # defaults to 1 for backwards compatibility
+    number_of_blocks: int | None = None,
 ) -> (dict, bool):
     """Calculate non-sequential cheapest hours.
 
@@ -273,11 +275,26 @@ def calculate_non_sequential_cheapest_hours(
     # Save all available slots unsorted --> replaced data.sort(key=lambda x: (x["price"], x["start"], x["end"]), reverse=inversed)
     all_window_slots = list(data)
 
+    # Initialize max_seq_slots to None by default
+    max_seq_slots: int | None = None
+
+    # Translate number_of_blocks to min_seq_slots and max_seq_slots if provided
+    if number_of_blocks and number_of_blocks > 0:
+        if min_seq_slots > 1:
+            _LOGGER.debug(
+                "Both number_of_blocks and min_seq_slots were provided. "
+                "number_of_blocks will take precedence."
+            )
+        effective_blocks = min(number_of_blocks, number_of_slots)
+        min_seq_slots = number_of_slots // effective_blocks
+        max_seq_slots = math.ceil(number_of_slots / effective_blocks)
+
     # Select base slots according to min_seq_slots info.
     base_slots = _select_slots_with_min_seq_slot_size(
         all_window_slots,
         number_of_slots,
         min_seq_slots=min_seq_slots,
+        max_seq_slots=max_seq_slots,
         inversed=inversed,
     )
 
@@ -390,16 +407,38 @@ def _select_flexible_slots(
     return selected
 
 
+def _would_exceed_max_seq(
+    selected: set[int], new_indices: set[int], max_seq: int | None
+) -> bool:
+    """Check if adding new_indices to selected creates a contiguous block larger than max_seq."""
+    if max_seq is None:
+        return False
+
+    combined = selected | new_indices
+    for idx in new_indices:
+        left = idx
+        while (left - 1) in combined:
+            left -= 1
+        right = idx
+        while (right + 1) in combined:
+            right += 1
+
+        if (right - left + 1) > max_seq:
+            return True
+    return False
+
+
 def _select_slots_with_min_seq_slot_size(
     data: list[dict],
     number_of_slots: int,
     min_seq_slots: int = 1,
+    max_seq_slots: int | None = None,
     inversed: bool = False,
 ) -> list[dict]:
-    """Select base slots with min_seq_slots and inversed logic."""
+    """Select base slots with min_seq_slots, max_seq_slots, and inversed logic."""
 
     # IF min_seq_slots == 1: keep original behavior
-    if min_seq_slots <= 1:
+    if min_seq_slots <= 1 and max_seq_slots is None:
         sorted_data = sorted(data, key=lambda x: x["price"], reverse=inversed)
         return sorted_data[:number_of_slots]
 
@@ -409,7 +448,7 @@ def _select_slots_with_min_seq_slot_size(
     selected_indices: set[int] = set()
     needed = number_of_slots
 
-    # Phase A: Select blocks based on min_seq_slots
+    # Phase A: Select blocks based on min_seq_slots (respecting max_seq_slots)
     while needed >= min_seq_slots:
         best_idx = -1
         best_score = float("inf")
@@ -418,6 +457,10 @@ def _select_slots_with_min_seq_slot_size(
             window = set(range(i, i + min_seq_slots))
             if window & selected_indices:
                 continue  # Continue on overlapping slots which are already part of the selected_indices
+
+            # Check if adding this window would merge with an adjacent block and exceed max_seq_slots
+            if _would_exceed_max_seq(selected_indices, window, max_seq_slots):
+                continue
 
             avg_price = sum(data[j]["price"] for j in window) / min_seq_slots
             score = avg_price * mult
@@ -432,7 +475,7 @@ def _select_slots_with_min_seq_slot_size(
         selected_indices.update(range(best_idx, best_idx + min_seq_slots))
         needed -= min_seq_slots
 
-    # Phase B: Add remaining slots to the current borders of selected slots to keep the min_seq_slots rule.
+    # Phase B: Add remaining slots to the current borders of selected slots to keep the min_seq_slots rule (respecting max_seq_slots).
     while needed > 0 and len(selected_indices) < total_available:
         best_idx = -1
         best_score = float("inf")
@@ -443,6 +486,10 @@ def _select_slots_with_min_seq_slot_size(
 
             # Check if selected slot is next to an already chosen slot
             if (i - 1 in selected_indices) or (i + 1 in selected_indices):
+                # Check max_seq_slots limit before attaching to border
+                if _would_exceed_max_seq(selected_indices, {i}, max_seq_slots):
+                    continue
+
                 score = data[i]["price"] * mult
                 if score < best_score:
                     best_score = score
@@ -452,12 +499,20 @@ def _select_slots_with_min_seq_slot_size(
             selected_indices.add(best_idx)
             needed -= 1
         else:
-            # Failsafe: in case no match to attach remaining slots to borders, just select the cheapest slots. This could happen when min_seq_slots is higher than number_of_slots
-            remaining = sorted(
-                [i for i in range(total_available) if i not in selected_indices],
-                key=lambda idx: data[idx]["price"] * mult,
-            )
-            selected_indices.update(remaining[:needed])
+            # Failsafe: in case no match to attach remaining slots to borders, just select the cheapest slots. This could happen when min_seq_slots is higher than number_of_slots while don't violating max_seq_slots
+            remaining = [
+                i
+                for i in range(total_available)
+                if i not in selected_indices
+                and not _would_exceed_max_seq(selected_indices, {i}, max_seq_slots)
+            ]
+            remaining.sort(key=lambda idx: data[idx]["price"] * mult)
+            for idx in remaining:
+                if needed == 0:
+                    break
+                if not _would_exceed_max_seq(selected_indices, {idx}, max_seq_slots):
+                    selected_indices.add(idx)
+                    needed -= 1
             break
 
     return [data[i] for i in sorted(selected_indices)]

--- a/custom_components/aio_energy_management/const.py
+++ b/custom_components/aio_energy_management/const.py
@@ -23,6 +23,7 @@ CONF_STARTING_TODAY = "starting_today"
 CONF_NUMBER_OF_HOURS = "number_of_hours"
 CONF_NUMBER_OF_SLOTS = "number_of_slots"
 CONF_MIN_SEQ_SLOTS = "min_seq_slots"
+CONF_NUMBER_OF_BLOCKS = "number_of_blocks"
 CONF_FAILSAFE_STARTING_HOUR = "failsafe_starting_hour"
 CONF_INVERSED = "inversed"
 CONF_TRIGGER_TIME = "trigger_time"  # DEPRECATED: use trigger_hour instead

--- a/custom_components/aio_energy_management/strings.json
+++ b/custom_components/aio_energy_management/strings.json
@@ -132,6 +132,7 @@
           "flexible_price_limit": "Flexible: price limit (static value)",
           "flexible_price_limit_entity": "Flexible: price limit (dynamic entity)",
           "min_seq_slots": "Minimum sequential slots",
+          "number_of_blocks": "Number of time blocks",
           "calendar": "Add to calendar",
           "mtu": "MTU (minutes)",
           "retention_days": "Retention days",
@@ -151,6 +152,7 @@
           "flexible_price_limit": "Flexible slots: only add extra slots whose price is below this value (or above if inversed). Requires the max number of slots",
           "flexible_price_limit_entity": "Optional: Entity to dynamically set the flexible price limit (sensor or input_number). Overrides static value if set",
           "min_seq_slots": "Enforce a number of continuous slots",
+          "number_of_blocks": "Divides the number of slots over the given number of blocks in order to get multiple blocks a day",
           "calendar": "Show this entity in the calendar",
           "mtu": "Market time unit in minutes (15 or 60)",
           "retention_days": "Number of days to keep calendar history",
@@ -265,6 +267,7 @@
       "end_minutes_out_of_range": "End offset minutes must be between 0 and 59",
       "both_consumption_configured": "Please configure only one: either static consumption (W) or consumption entity, not both",
       "device_name_required": "Device name is required",
+      "number_of_blocks_out_of_range": "Nuimber of blocks must be at least 1",
       "unknown": "Unexpected error occurred"
     },
     "abort": {

--- a/custom_components/aio_energy_management/translations/en.json
+++ b/custom_components/aio_energy_management/translations/en.json
@@ -132,6 +132,7 @@
           "flexible_price_limit": "Flexible: price limit (static value)",
           "flexible_price_limit_entity": "Flexible: price limit (dynamic entity)",
           "min_seq_slots": "Minimum sequential slots",
+          "number_of_blocks": "Number of time blocks",
           "calendar": "Add to calendar",
           "mtu": "MTU (minutes)",
           "retention_days": "Retention days",
@@ -151,6 +152,7 @@
           "flexible_price_limit": "Flexible slots: only add extra slots whose price is below this value (or above if inversed). Requires the max number of slots",
           "flexible_price_limit_entity": "Optional: Entity to dynamically set the flexible price limit (sensor or input_number). Overrides static value if set",
           "min_seq_slots": "Enforce a number of continuous slots",
+          "number_of_blocks": "Divides the number of slots over the given number of blocks in order to get multiple blocks a day",
           "calendar": "Show this entity in the calendar",
           "mtu": "Market time unit in minutes (15 or 60)",
           "retention_days": "Number of days to keep calendar history",
@@ -265,6 +267,7 @@
       "end_minutes_out_of_range": "End offset minutes must be between 0 and 59",
       "both_consumption_configured": "Please configure only one: either static consumption (W) or consumption entity, not both",
       "device_name_required": "Device name is required",
+      "number_of_blocks_out_of_range": "Nuimber of blocks must be at least 1",
       "unknown": "Unexpected error occurred"
     },
     "abort": {

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -13,6 +13,7 @@ from custom_components.aio_energy_management.models.hour_price import HourPrice
 from freezegun import freeze_time
 import numpy as np
 import pytest
+import math
 
 
 @pytest.fixture
@@ -785,3 +786,78 @@ def test_cheapest_hours_min_seq_slots_scenarios(
         duration_minutes = (seq_slots["end"] - seq_slots["start"]).total_seconds() / 60
         slots_count = int(duration_minutes / 60)
         assert slots_count >= min_seq_slots
+
+
+@pytest.mark.parametrize(
+    "number_of_slots, number_of_blocks, inversed, expected_ranges",
+    [
+        # Example 1: 6 slots divided by 2 blocks
+        (6, 2, False, [("01:00", "04:00"), ("12:00", "15:00")]),
+        # Example 2: 7 slots divided by 2 blocks
+        (7, 2, False, [("01:00", "05:00"), ("12:00", "15:00")]),
+        # Example 3: 9 slots divided by 3 blocks
+        (9, 3, False, [("01:00", "04:00"), ("08:00", "11:00"), ("12:00", "15:00")]),
+        # Example 4: 10 slots divided by 3 blocks
+        (10, 3, False, [("01:00", "05:00"), ("08:00", "11:00"), ("12:00", "15:00")]),
+        # Example 4: Inversed, 4 slots divided by 2 blocks
+        (4, 2, True, [("11:00", "13:00"), ("14:00", "16:00")]),
+    ],
+)
+def test_cheapest_hours_number_of_blocks_scenarios(
+    today_valid2,
+    tomorrow_valid,
+    number_of_slots: int,
+    number_of_blocks: int,
+    inversed: bool,
+    expected_ranges: list[tuple[str, str]],
+) -> None:
+    """Test non-sequential cheapest/expensive hours respecting number_of_blocks."""
+
+    result, _ = calculate_non_sequential_cheapest_hours(
+        today=today_valid2,
+        tomorrow=tomorrow_valid,
+        number_of_slots=number_of_slots,
+        starting_today=False,
+        first_hour=0,
+        last_hour=23,
+        number_of_blocks=number_of_blocks,
+        inversed=inversed,
+    )
+
+    # Format outcomes to readable time windows
+    actual_ranges = [
+        (
+            seq_slots["start"].strftime("%H:%M"),
+            seq_slots["end"].strftime("%H:%M"),
+        )
+        for seq_slots in result["list"]
+    ]
+
+    # 1. Check if the generated ranges match the exact expectations
+    assert actual_ranges == expected_ranges
+
+    # 2. Basic payload checks
+    assert isinstance(result, dict)
+    assert "list" in result
+    assert "extra" in result
+    assert len(result["list"]) > 0
+
+    # 3. Calculate expected boundaries for block sizes
+    effective_blocks = min(number_of_blocks, number_of_slots)
+    expected_min_seq = number_of_slots // effective_blocks
+    expected_max_seq = math.ceil(number_of_slots / effective_blocks)
+
+    # 4. Check if the number of returned blocks matches expected number of blocks
+    assert len(result["list"]) == effective_blocks
+
+    # 5. Check if each block respects the calculated min and max bounds
+    total_slots_selected = 0
+    for seq_slots in result["list"]:
+        duration_minutes = (seq_slots["end"] - seq_slots["start"]).total_seconds() / 60
+        slots_count = int(duration_minutes / 60)
+
+        assert expected_min_seq <= slots_count <= expected_max_seq
+        total_slots_selected += slots_count
+
+    # 6. Check if the total selected slots equal requested number_of_slots
+    assert total_slots_selected == number_of_slots


### PR DESCRIPTION
**Summary**

This PR adds the number_of_blocks parameter for non-sequential calculation modes. It allows users to automatically divide their total target slots/hours into a fixed number of separate continuous blocks throughout the day.

This is particularly useful for appliances like washing machines, or pool pumps that need to run multiple distinct cycles per day with required pause/cooling-off periods in between. Another benefit of this feature that it could potentially return 1 block during nighttime, one block during day time to get a optimized distribution of blocks. 

**Interaction Rules**

min_seq_slots Override: When number_of_blocks is set, min_seq_slots is automatically ignored to ensure the exact requested number of blocks can be calculated.

Enforced Gaps: Adjacent slots are separated by at least 1 slot gap to ensure Home Assistant correctly triggers state changes (OFF -> ON) between operational runs.

The math is pretty mush the same as for the min_seq_slots, but it uses an extra non-configurable attribute which is determined by the number_of_blocks. 

It addresses this open issue: https://github.com/kotope/aio_energy_management/issues/113